### PR TITLE
Update time values with setDate, when relevant

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -208,7 +208,7 @@ flatpickr.init = function (element, instanceConfig) {
         return self.l10n.daysInMonth[month];
     };
 
-    updateValue = function(){
+    updateValue = function(triggerChangeEvent){
 
         if (self.selectedDateObj && self.config.enableTime ){
 
@@ -234,7 +234,9 @@ flatpickr.init = function (element, instanceConfig) {
         if ( self.selectedDateObj )
             self.input.value = formatDate(self.config.dateFormat);
 
-        triggerChange();
+        if (triggerChangeEvent !== false) {
+            triggerChange();
+        }
 
     };
 
@@ -718,7 +720,7 @@ flatpickr.init = function (element, instanceConfig) {
 
         self.selectedDateObj = uDate(date);
         self.jumpToDate(self.selectedDateObj);
-        updateValue();
+        updateValue(false);
 
         triggerChangeEvent = triggerChangeEvent||false;
         if(triggerChangeEvent)

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -700,6 +700,16 @@ flatpickr.init = function (element, instanceConfig) {
         );
         self.currentYear = jumpDate.getFullYear();
         self.currentMonth = jumpDate.getMonth();
+
+        if (self.config.enableTime && hourElement && minuteElement) {
+            hourElement.value = jumpDate.getHours();
+            minuteElement.value = jumpDate.getMinutes();
+
+            if (am_pm) {
+                am_pm.innerHTML = jumpDate.getHours() > 11 ? 'PM' : 'AM';
+            }
+        }
+
         self.redraw();
 
     };


### PR DESCRIPTION
There doesn't appear to be a way currently to dynamically change the selected time. This commit modifies setDate so if the picker has time enabled, the time will be updated along with the date.