### PR TITLE
add ability to parse date using a user-defined date-string parser

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,6 +464,13 @@ flatpickr(".flatpickr")
 				</tr>
 
 				<tr>
+					<td>parseDate</td>
+					<td>function</td>
+					<td>false</td>,
+					<td>A function that expects a date string and must return a Date object</td>
+				</tr>
+
+				<tr>
 					<td>minDate</td>
 					<td>String</td>
 					<td>null</td>

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -177,7 +177,10 @@ flatpickr.init = function(element, instanceConfig) {
 
 			date = date.trim();
 
-			if (/^\d\d\d\d\-\d\d\-\d\d/.test(date)) // disable special utc datestring
+			if (self.config.parseDate)
+				date = self.config.parseDate(date);
+
+			else if (/^\d\d\d\d\-\d\d\-\d\d/.test(date)) // disable special utc datestring
 				date = new Date(date.replace(/(\d)-(\d)/g, "$1/$2") );
 
 			else if (/^(\d?\d):(\d\d)/.test(date)){ // time-only picker
@@ -945,6 +948,9 @@ flatpickr.init.prototype = {
 
 			// the maximum date that user can pick (inclusive)
 			maxDate: null,
+
+			// dateparser that transforms a given string to a date object
+			parseDate: false,
 
 			// see https://chmln.github.io/flatpickr/#disable
 			disable: [],


### PR DESCRIPTION
hi,

this pull-request enables flatpickr to use a custom date parser instead of the built-in method. this way it’s possible to use advanced parsers like the one moment.js provides.