### PR TITLE
Updated text color in dark theme style

### DIFF
--- a/src/style/flatpickr_base.styl
+++ b/src/style/flatpickr_base.styl
@@ -249,7 +249,8 @@ $width = 256px
 	height 38px
 	display inline-block
 	line-height 38px
-
+	color $day_text_color
+	
 .flatpickr-am-pm
 	width 21%
 	padding 0 2%


### PR DESCRIPTION
fixed the missing text color in dark theme style for time separator and am-pm text