### PR TITLE
Fix issue with invalid time inputs

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -265,12 +265,12 @@ flatpickr.init = function(element, instanceConfig) {
 			prev_date = self.selectedDateObj.getTime();
 
 			// update time
-			var hours = parseInt(hourElement.value, 10),
-				minutes = (60+parseInt(minuteElement.value, 10))%60,
+			var hours = (parseInt(hourElement.value, 10) || 0),
+				minutes = (60 + (parseInt(minuteElement.value, 10) || 0)) % 60,
 				seconds;
 
 			if(self.config.enableSeconds)
-				seconds = (60+parseInt(secondElement.value, 10))%60;
+				seconds = (60 + (parseInt(secondElement.value, 10)) || 0) % 60;
 
 			if (!self.config.time_24hr)
 				hours = hours%12 + 12*(am_pm.innerHTML=== "PM");


### PR DESCRIPTION
Typing something other than a digit into a time input causes parseInt to return NaN, which breaks a bunch of stuff. Once the time picker is broken, it can't be fixed without refreshing the page, even if the input field is cleared and a number is added.

This patch causes NaN results to become 0, which will prevent this problem from popping up.