### PR TITLE
Updated parseConfig

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -624,11 +624,15 @@ function Flatpickr(element, config) {
 			self.config.dateFormat = Flatpickr.defaultConfig.dateFormat;
 			if (self.config.noCalendar) { // time picker
 				self.config.dateFormat = "H:i" + (self.config.enableSeconds ? ":S" : "");
-				self.config.altFormat = "h:i" + (self.config.enableSeconds ? ":S K" : " K");
+                		if(!self.config.altInput) {
+                    			self.config.altFormat = "h:i" + (self.config.enableSeconds ? ":S K" : " K");
+                		}
 			}
 			else {
 				self.config.dateFormat += " H:i" + (self.config.enableSeconds ? ":S" : "");
-				self.config.altFormat = `h:i${self.config.enableSeconds ? ":S" : ""} K`;
+                		if(!self.config.altInput) {
+                    			self.config.altFormat = "h:i" + (self.config.enableSeconds ? ":S" : "") + " K";
+                		}
 			}
 		}
 		Object.keys(Flatpickr.defaultConfig).forEach(k =>


### PR DESCRIPTION
This commit fixes #276 
When setting enableTime to true so that the time picker appears with the calendar, the altFormat is overwritten with a fixed time format and no date.
These updated changes to the parseConfig routine take into account the altInput field so that the self.config.altFormat is not overwritten if altInput is true.  Without this, altFormat is overwritten whenever self.config.enableTime is true; if you wanted the time selector, then you couldn't have an alternative human friendly view of the time.
