### PR TITLE
Fix first day of week for l10n.fr

### DIFF
--- a/src/flatpickr.l10n.fr.js
+++ b/src/flatpickr.l10n.fr.js
@@ -1,6 +1,8 @@
 /* French locals for flatpickr */
 var Flatpickr = Flatpickr||{l10n: {}};
 
+Flatpickr.l10n.firstDayOfWeek = 1;
+
 Flatpickr.l10n.weekdays = {
 	shorthand: ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'],
 	longhand: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']


### PR DESCRIPTION
Hi,
I've switched first day of week to 1 for the FR l10n since it's what's most common, in France at least.
(in the right branch this time)