### PR TITLE
fix AM/PM calculations when hour is 12

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -75,11 +75,13 @@ function Flatpickr(element, config) {
 		if (!self.config.enableTime)
 			return;
 
-		let hours = (parseInt(self.hourElement.value, 10) || 0) + 12 * (!self.config.time_24hr && self.amPM.innerHTML === "PM"),
+		let hours = (parseInt(self.hourElement.value, 10) || 0),
 			minutes = (60 + (parseInt(self.minuteElement.value, 10) || 0)) % 60,
 			seconds = self.config.enableSeconds
 				? (60 + (parseInt(self.secondElement.value, 10)) || 0) % 60
 				: 0;
+
+		if (self.amPM) hours = (hours % 12) + (12 * (self.amPM.innerHTML === "PM"));
 
 		setHours(hours, minutes, seconds);
 	}


### PR DESCRIPTION
Fixes #379. The code is pretty terse to keep it close to the original, so it may be a little hard to reason about. This is what happens:

If AM/PM is enabled, then it will first do hours % 12 so that the value is 0 - 11. Then it will add 12 if the control is set to PM. This way:

* 12am -> 0
* 11am -> 11
* 12pm -> 12
* 11pm -> 23
