### PR TITLE
Added 'position' to config, can specify 'above' or 'below'

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1,4 +1,5 @@
 /*! flatpickr v2.1.1, @license MIT */
+
 function Flatpickr(element, config) {
 	const self = this;
 
@@ -1054,7 +1055,7 @@ function Flatpickr(element, config) {
 		let top,
 			left = (window.pageXOffset + inputBounds.left);
 
-		if (distanceFromBottom < calendarHeight) {
+		if (self.config.position == "above" || (self.config.position != "below" && distanceFromBottom < calendarHeight)) {
 			top = (window.pageYOffset - calendarHeight + inputBounds.top) - 2;
 			self.calendarContainer.classList.remove("arrowTop");
 			self.calendarContainer.classList.add("arrowBottom");


### PR DESCRIPTION
The logic for determining whether to place the calendar above or below was faulty in my opinion, especially on mobile devices where almost always it would appear off the top of the screen.  If the flatpickr wasn't far enough from the top of the page, much of it would be hidden and inaccessible, even to change months.  When shown below, the user can always scroll down, as they normally would on a mobile device when filling out a form.  This commit adds the ability to specify position of 'above' or 'below' which will force it to be one way or the other (for me, I'll always use 'below').