### PR TITLE
Internet Explorer compatibily fix

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1937,5 +1937,14 @@ if (
 	});
 }
 
+// IE Math.sign polyfill
+Math.sign = Math.sign || function(x) {
+	x = +x; // convert to a number
+	if (x === 0 || isNaN(x)) {
+		return Number(x);
+	}
+	return x > 0 ? 1 : -1;
+}
+
 if (typeof module !== "undefined")
 	module.exports = Flatpickr;


### PR DESCRIPTION
Internet Explorer unsupported Math.sign function (more info: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign).

This PR adds Math.sign polyfill for compatibility with IE.