### PR TITLE
support custom `formatDate`-function

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -755,6 +755,9 @@ function Flatpickr(element, config) {
 	}
 
 	function formatDate(frmt, dateObj) {
+		if (self.config.formatDate)
+			return self.config.formatDate(frmt, dateObj);
+
 		const chars = frmt.split("");
 		return chars.map((c, i) => self.formats[c] && chars[i - 1] !== "\\"
 			? self.formats[c](dateObj)
@@ -1702,6 +1705,9 @@ Flatpickr.defaultConfig = {
 
 	// dateparser that transforms a given string to a date object
 	parseDate: null,
+
+	// dateformatter that transforms a given date object to a string, according to passed format
+	formatDate: null,
 
 	getWeek: function (givenDate) {
 		const date = new Date(givenDate.getTime());

--- a/test/spec.js
+++ b/test/spec.js
@@ -191,6 +191,70 @@ describe('flatpickr', () => {
 
 	});
 
+	describe('date formatting', () => {
+		const DATE_STR = '2016-10-20 09:19:59';
+
+		describe('default formatter', () => {
+			const
+				DFEAULT_FORMAT_1 = 'd.m.y H:i:S',
+				DFEAULT_FORMAT_2 = 'D j F, \'y';
+
+			it(`should format the date with the pattern "${DFEAULT_FORMAT_1}"`, () => {
+				const RESULT = '20.10.16 09:19:59';
+				createInstance({
+					dateFormat: DFEAULT_FORMAT_1
+				});
+
+				fp.setDate(DATE_STR);
+				expect(fp.input.value).toEqual(RESULT);
+				fp.setDate('2015-11-21 19:29:49');
+				expect(fp.input.value).not.toEqual(RESULT);
+			});
+
+			it(`should format the date with the pattern "${DFEAULT_FORMAT_2}"`, () => {
+				const RESULT = 'Thu 20 October, \'16';
+				createInstance({
+					dateFormat: DFEAULT_FORMAT_2
+				});
+
+				fp.setDate(DATE_STR);
+				expect(fp.input.value).toEqual(RESULT);
+				fp.setDate('2015-11-21 19:29:49');
+				expect(fp.input.value).not.toEqual(RESULT);
+			});
+		});
+		describe('custom formatter', () => {
+			it('should format the date using the custom formatter', () => {
+				const RESULT = 'MAAAGIC.*^*.2016.*^*.20.*^*.10';
+				createInstance({
+					dateFormat: 'YEAR-DAYOFMONTH-MONTH',
+					formatDate(formatStr, date) {
+						let segs = formatStr.split('-');
+						return 'MAAAGIC.*^*.' + segs.map(seg => {
+								let mapped = null;
+								switch (seg) {
+									case 'DAYOFMONTH':
+										mapped = date.getDate();
+										break;
+									case 'MONTH':
+										mapped = date.getMonth() + 1;
+										break;
+									case 'YEAR':
+										mapped = date.getFullYear();
+										break;
+								}
+								return '' + mapped;
+							}).join('.*^*.');
+					}
+				});
+
+				fp.setDate(DATE_STR);
+				expect(fp.input.value).toEqual(RESULT);
+				fp.setDate('2015-11-21 19:29:49');
+				expect(fp.input.value).not.toEqual(RESULT);
+			});
+		});
+	});
 
 	describe("API", () => {
 		it("set (option, value)", () => {


### PR DESCRIPTION
Custom `formatDate`-support. To provide better integration with other i18n-modules (eg. `angular-i18n`)