### PR TITLE
Better startup performance

### DIFF
--- a/dist/flatpickr.js
+++ b/dist/flatpickr.js
@@ -1266,11 +1266,11 @@ function Flatpickr(element, config) {
 		e.target.value = self.currentYear;
 	}
 
-	function createElement(tag) {
-		var className = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "";
-		var content = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "";
-
+	function createElement(tag, className, content) {
 		var e = document.createElement(tag);
+		className = className || "";
+		content = content || "";
+
 		e.className = className;
 
 		if (content) e.textContent = content;

--- a/dist/flatpickr.js
+++ b/dist/flatpickr.js
@@ -91,7 +91,7 @@ function Flatpickr(element, config) {
 		    minutes = parseInt(self.minuteElement.value, 10) || 0,
 		    seconds = self.config.enableSeconds ? parseInt(self.secondElement.value, 10) || 0 : 0;
 
-		if (self.amPM) hours = hours % 12 + 12 * (self.amPM.innerHTML === "PM");
+		if (self.amPM) hours = hours % 12 + 12 * (self.amPM.textContent === "PM");
 
 		if (self.minDateHasTime && compareDates(self.latestSelectedDateObj, self.config.minDate) === 0) {
 			hours = Math.max(hours, self.config.minDate.getHours());
@@ -353,7 +353,7 @@ function Flatpickr(element, config) {
 
 		var dayNumber = self.prevMonthDays + 1 - self.firstOfMonth;
 
-		if (self.config.weekNumbers) self.weekNumbers.innerHTML = "";
+		if (self.config.weekNumbers && self.weekNumbers.firstChild) self.weekNumbers.textContent = "";
 
 		if (self.config.mode === "range") {
 			// const dateLimits = self.config.enable.length || self.config.disable.length || self.config.mixDate || self.config.maxDate;
@@ -361,7 +361,7 @@ function Flatpickr(element, config) {
 			self.maxRangeDate = new Date(self.currentYear, self.currentMonth + 1, (42 - self.firstOfMonth) % daysInMonth);
 		}
 
-		self.days.innerHTML = "";
+		if (self.days.firstChild) self.days.textContent = "";
 
 		// prepend days from the ending of previous month
 		for (var i = 0; dayNumber <= self.prevMonthDays; i++, dayNumber++) {
@@ -1273,7 +1273,7 @@ function Flatpickr(element, config) {
 		var e = document.createElement(tag);
 		e.className = className;
 
-		if (content) e.innerHTML = content;
+		if (content) e.textContent = content;
 
 		return e;
 	}
@@ -1337,7 +1337,7 @@ function Flatpickr(element, config) {
 				newValue = e.target === self.hourElement ? newValue - max - !self.amPM : min;
 			}
 
-			if (self.amPM && e.target === self.hourElement && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) self.amPM.textContent = self.amPM.innerHTML === "PM" ? "AM" : "PM";
+			if (self.amPM && e.target === self.hourElement && (step === 1 ? newValue + curValue === 23 : Math.abs(newValue - curValue) > step)) self.amPM.textContent = self.amPM.textContent === "PM" ? "AM" : "PM";
 
 			e.target.value = self.pad(newValue);
 		} else e.target.value = newValue;

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -114,7 +114,7 @@ function Flatpickr(element, config) {
 				: 0;
 
 		if (self.amPM)
-			hours = (hours % 12) + (12 * (self.amPM.innerHTML === "PM"));
+			hours = (hours % 12) + (12 * (self.amPM.textContent === "PM"));
 
 		if (
 			self.minDateHasTime
@@ -450,8 +450,8 @@ function Flatpickr(element, config) {
 
 		let	dayNumber = self.prevMonthDays + 1 - self.firstOfMonth;
 
-		if (self.config.weekNumbers)
-			self.weekNumbers.innerHTML = "";
+		if (self.config.weekNumbers && self.weekNumbers.firstChild)
+			self.weekNumbers.textContent = "";
 
 		if (self.config.mode === "range") {
 			// const dateLimits = self.config.enable.length || self.config.disable.length || self.config.mixDate || self.config.maxDate;
@@ -463,7 +463,8 @@ function Flatpickr(element, config) {
 			);
 		}
 
-		self.days.innerHTML = "";
+		if (self.days.firstChild)
+			self.days.textContent = "";
 
 		// prepend days from the ending of previous month
 		for (let i = 0; dayNumber <= self.prevMonthDays; i++, dayNumber++) {
@@ -1579,7 +1580,7 @@ function Flatpickr(element, config) {
 		e.className = className;
 
 		if (content)
-			e.innerHTML = content;
+			e.textContent = content;
 
 		return e;
 	}
@@ -1656,7 +1657,7 @@ function Flatpickr(element, config) {
 					? newValue + curValue === 23
 					: Math.abs(newValue - curValue) > step)
 			)
-				self.amPM.textContent = self.amPM.innerHTML === "PM" ? "AM" : "PM";
+				self.amPM.textContent = self.amPM.textContent === "PM" ? "AM" : "PM";
 
 			e.target.value = self.pad(newValue);
 		}

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1575,8 +1575,11 @@ function Flatpickr(element, config) {
 		e.target.value = self.currentYear;
 	}
 
-	function createElement(tag, className = "", content = "") {
+	function createElement(tag, className, content) {
 		const e = document.createElement(tag);
+		className = className || "";
+		content = content || "";
+
 		e.className = className;
 
 		if (content)


### PR DESCRIPTION
### What

I've dropped most uses of innerHTML, as textContent is like 5x faster for these tiny text-only strings. The prevArrow/nextArrow are still using innerHTML, due to the inline SVGs. It'd be nice to avoid innerHTML here, but that's a larger refactor.

I've also removed the default parameters for `createElement` as the compiled version relied on `arguments` which isn't very performant in a hot path.

### Results

On my macbook air, I'm seeing the times of `build()` go **from ~9ms to ~2ms**.
For the demo page, the full startup has gone **from ~400ms to ~230ms**.

So, let's average that out and say we're **~300% faster**. 🔥 


### Seeing it

Here's a before and after trace: https://chromedevtools.github.io/timeline-viewer/?loadTimelineFromURL=https://www.dropbox.com/s/7238b2rphoof6j7/flatpickr-before.json?dl=0,%20https://www.dropbox.com/s/byyqvjqzqjj37ur/flatpickr-after.json?dl=0

Screenshot:
![image](https://cloud.githubusercontent.com/assets/39191/21597170/0ed180e0-d114-11e6-9f77-5eaffbbded80.png)

(You'll see the big forced layouts in `positionCalendar`.. It may be possible to avoid those, but luckily, it only hits during startup for the `inline` configuration.)