### PR TITLE
Set max in range limit example to future

### DIFF
--- a/site/content/examples.pug
+++ b/site/content/examples.pug
@@ -54,7 +54,7 @@ section#example-minMaxDate
 		code.js.
 			flatpickr(".flatpickr", {
 				minDate: new Date(), // "today" / "2016-12-20" / 1477673788975
-				maxDate: "2016-12-20",
+				maxDate: "2017-12-20",
 				enableTime: true,
 
 				// create an extra input solely for display purposes
@@ -69,7 +69,7 @@ section#example-minMaxDate
 		data-enable-time="true",
 		data-alt-format="F j, Y h:i K",
 		data-min-date="today",
-		data-max-date="2016-12-20"
+		data-max-date="2017-12-20"
 	)
 
 section#example-preload


### PR DESCRIPTION
Currently, the example uses a max date in the past rendering the demo unusable. This change moves the max date to the future. I guess this problem will happen again in a year, but for the sake of documentation brevity, I figure this is the best solution.