### PR TITLE
fix range mode styling in IE11

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -960,14 +960,18 @@ function Flatpickr(element, config) {
 
 			if (outOfRange) {
 				self.days.childNodes[i].classList.add("notAllowed");
-				self.days.childNodes[i].classList.remove("inRange", "startRange", "endRange");
+				["inRange", "startRange", "endRange"].forEach(c => {
+					self.days.childNodes[i].classList.remove(c)				
+				});
 				continue;
 			}
 
 			else if (containsDisabled && !outOfRange)
 				continue;
 
-			self.days.childNodes[i].classList.remove("startRange", "inRange", "endRange", "notAllowed");
+			["startRange", "inRange", "endRange", "notAllowed"].forEach(c => {
+				self.days.childNodes[i].classList.remove(c)
+			});
 
 			const minRangeDate = Math.max(self.minRangeDate.getTime(), rangeStartDate),
 				maxRangeDate = Math.min(self.maxRangeDate.getTime(), rangeEndDate);


### PR DESCRIPTION
IE11 has classlist, but it does not support multiple arguments for add() and remove().

Since it is used in 2 places in range mode related code, the picker renders weirdly, like this:
![bug_flatpickr](https://cloud.githubusercontent.com/assets/371494/22014973/653759ea-dca0-11e6-9006-6c7638dd2c3d.jpg)

See http://caniuse.com/#feat=classlist