### PR TITLE
New format to be able to post date value in UTC

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1441,6 +1441,9 @@ function Flatpickr(element, config) {
 	/* istanbul ignore next */
 	function setupFormats() {
 		self.formats = {
+			// get the date in UTC
+			Z: date => date.toUTCString(),
+			
 			// weekday name, short, e.g. Thu
 			D: date => self.l10n.weekdays.shorthand[self.formats.w(date)],
 

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1442,7 +1442,7 @@ function Flatpickr(element, config) {
 	function setupFormats() {
 		self.formats = {
 			// get the date in UTC
-			Z: date => date.toUTCString(),
+			Z: date => date.toISOString(),
 			
 			// weekday name, short, e.g. Thu
 			D: date => self.l10n.weekdays.shorthand[self.formats.w(date)],


### PR DESCRIPTION
New date format "Z" that formats the entire date value using toUTCString(). Useful for the config.dateFormat as it allows to POST date value converted to UTC to the web server while allowing the user to manipulate the date in local time thanks to config.altFormat.