### PR TITLE
Better style for range mode if start, end date are the same

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -415,11 +415,12 @@ function Flatpickr(element, config) {
 				dayElement.classList.add("selected");
 
 				if (self.config.mode === "range") {
-					dayElement.classList.add(
-						compareDates(date, self.selectedDates[0]) === 0
-							? "startRange"
-							: "endRange"
-						);
+					if (compareDates(date, self.selectedDates[0]) === 0) {
+						dayElement.classList.add("startRange");
+					}
+					if (compareDates(date, self.selectedDates[1]) === 0) {
+						dayElement.classList.add("endRange");
+					}
 				}
 
 				else

--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -426,6 +426,9 @@ $invertedBg = invert($calendarBackground)
         &.endRange
             border-radius 0 50px 50px 0
 
+        &.startRange.endRange
+            border-radius 50px
+
     &.inRange
         border-radius 0
         box-shadow: (-2.5*$dayMargin) 0 0 $dayHoverBackground, (2.5*$dayMargin) 0 0 $dayHoverBackground


### PR DESCRIPTION
On range mode, when start and end date are the same.
Make the box become a circle (it will be styled as startRange now).

![2017-02-08 4 14 54](https://cloud.githubusercontent.com/assets/16474/22728619/f35003c8-ee19-11e6-8454-07090f678266.png)
