### PR TITLE
Call `setupLocale` if change locale from api

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1310,6 +1310,9 @@ function Flatpickr(element, config) {
 
 	function set(option, value) {
 		self.config[option] = value;
+		if (option === 'locale') {
+			setupLocale();
+		}
 		self.redraw();
 		jumpToDate();
 	}


### PR DESCRIPTION
If user use `set()` to change locale.
Call `setupLocale` to make the change work.