### PR TITLE
set selected date after parsing rules

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1418,13 +1418,13 @@ function Flatpickr(element, config) {
 		self.selectedDates = [];
 		self.now = new Date();
 
-		setSelectedDate(self.config.defaultDate || self.input.value);
-
 		if (self.config.disable.length)
 			self.config.disable = parseDateRules(self.config.disable);
 
 		if (self.config.enable.length)
 			self.config.enable = parseDateRules(self.config.enable);
+
+		setSelectedDate(self.config.defaultDate || self.input.value);
 
 		const initialDate = (self.selectedDates.length
 			? self.selectedDates[0]


### PR DESCRIPTION
When I set `enable: {from: "today"}` to 3 inputs, the first input became empty.
```html
<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
<script src='src/flatpickr.js'></script>
<link rel='stylesheet' href='dist/flatpickr.css'></script>

<input value=2017-02-23 class='pickr-input'><!-- any future date -->
<input value=2017-02-23 class='pickr-input'>
<input value=2017-02-23 class='pickr-input'>
<script>
$(function(){
  var config = {
      altInput: true,
      enable: [
        {
          from: 'today',
          to: new Date().fp_incr(99999)
        }
      ]
    }
  $('.pickr-input').flatpickr(config)
})
</script>
```
result: 
![2017-02-17 18 53 05](https://cloud.githubusercontent.com/assets/1780201/23060930/23608e68-f543-11e6-8c94-61dd20b71f8c.png)

expected:
![2017-02-17 18 58 15](https://cloud.githubusercontent.com/assets/1780201/23060935/2611beb6-f543-11e6-9eb2-0dcbbd95ddd1.png)

this pull fix the order of parsing enable&disable rules and setSelectedDate.
setSelectedDate after "today"(string) has been overwritten to Date).
