### PR TITLE
Add rangeSeparator for Estonian l10n

### DIFF
--- a/src/l10n/et.js
+++ b/src/l10n/et.js
@@ -19,6 +19,7 @@ Flatpickr.l10ns.et.ordinal = function() {
 };
 
 Flatpickr.l10ns.et.weekAbbreviation = "Näd";
+Flatpickr.l10ns.et.rangeSeparator = " kuni ";
 Flatpickr.l10ns.et.scrollTitle = "Keri, et suurendada";
 Flatpickr.l10ns.et.toggleTitle = "Klõpsa, et vahetada";
 


### PR DESCRIPTION
Pretty straightforward, noticed a translation was missing when using flatpickr in one of our projects.