### PR TITLE
Clean instance config object

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1169,8 +1169,9 @@ function Flatpickr(element, config) {
 		for (let i = 0; i < boolOpts.length; i++)
 			self.config[boolOpts[i]] = (self.config[boolOpts[i]] === true) || self.config[boolOpts[i]] === "true";
 
-		for (let i = 0; i < hooks.length; i++)
-			self.config[hooks[i]] = arrayify(self.config[hooks[i]]);
+		for (let i = 0; i < hooks.length; i++) {
+			self.config[hooks[i]] = arrayify(self.config[hooks[i]] || []);
+		}
 
 
 		if (!userConfig.dateFormat && userConfig.enableTime) {

--- a/test/flatpickr.spec.js
+++ b/test/flatpickr.spec.js
@@ -119,6 +119,14 @@ describe('flatpickr', () => {
 			expect(fp.selectedDates.length).toBe(0);
 			expect(fp.days.querySelector(".selected")).toEqual(null);
 		});
+
+		it("doesn't throw with undefined properties", () => {
+			createInstance({
+				onChange: undefined,
+			});
+			fp.set("minDate", "2016-10-20");
+			expect(fp.config.minDate).toBeDefined();
+		});
 	});
 
 	describe("datetimestring parser", () => {


### PR DESCRIPTION
If we pass a configuration object with `undefined` values for the hooks the property is set and an update triggers a TypeError:

```js
new Flatpickr(element, {
  onChange: undefined
});
```

![screen shot 2017-02-21 at 23 42 01](https://cloud.githubusercontent.com/assets/5436545/23188583/85b7fcfa-f88f-11e6-8211-3b10decbb5ba.png)

I fixed it by removing all undefined values on the `instanceConfig` object. Unfortunately I couldn't use the trick `JSON.parse(JSON.stringify(obj))` because there are functions in the object. Hence I created a function to clean an object.
