### PR TITLE
position calendar instances over inputs before becoming "open"

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -263,6 +263,16 @@ function Flatpickr(element, config) {
 				});
 			}
 		}
+		if (self.config.static) return;
+		if (self.config.inline) return;
+		// set the calendar position
+		// even though it's hidden to prevent Safari from jumping to
+		// the top of the page and then scrolling down
+		positionCalendar();
+		// run it again when the page has loaded
+		window.addEventListener("load", function(e) {
+			positionCalendar();
+		});
 	}
 
 	function jumpToDate(jumpDate) {
@@ -1047,8 +1057,9 @@ function Flatpickr(element, config) {
 	}
 
 	function onResize() {
-		if (self.isOpen && !self.config.static && !self.config.inline)
-			positionCalendar();
+		if (!self.config.inline) return;
+		if (!self.config.static) return;
+		positionCalendar();
 	}
 
 	function open(e) {


### PR DESCRIPTION

* call positionCalendar on bind and then on document loaded
* Fixes #652