### PR TITLE
Allow hooks to be a single function or an array of functions

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1641,9 +1641,15 @@ function Flatpickr(element, config) {
 	}
 
 	function triggerEvent(event, data) {
-		const hooks = self.config["on" + event];
+		let hooks = self.config["on" + event];
 
 		if (hooks) {
+			if (!Array.isArray(hooks) && typeof hooks === 'function') {
+				const hook = hooks;
+				hooks = [];
+				hooks.push(hook);
+			}
+
 			for (let i = 0; i < hooks.length; i++)
 				hooks[i](self.selectedDates, self.input && self.input.value, self, data);
 		}


### PR DESCRIPTION
I hope I'm not mistaken but this feature found in the documentation (https://chmln.github.io/flatpickr/events/) was not working for me. Hooks needed to be put in an array for them to work and single functions threw an error.