### PR TITLE
[docs] setDate triggerChange inverted behaviour

### DIFF
--- a/content/instance.md
+++ b/content/instance.md
@@ -79,7 +79,7 @@ Sets a config option `option`to `value`, redrawing the calendar and updating t
 
 Sets the current selected date(s) to`date`, which can be a date string, a Date, or an`Array` of the Dates.
 
-Optionally, pass true as the second argument to force any onChange events to fire.
+Optionally, pass false as the second argument to force any onChange events not to fire.
 
 
 ### `toggle()`


### PR DESCRIPTION
[File Reference](https://github.com/chmln/flatpickr/blob/master/src/flatpickr.js#L1450)

In docs it's implied that onChange events not firing is the default behaviour, but the default behaviour is to fire onChange event, unless false is passed as argument.