### PR TITLE
fix(css): Add [readonly] condition to cursor style

### DIFF
--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -617,5 +617,5 @@ if $noCalendarBorder
             top 0 !important
 
 
-.flatpickr-input
+.flatpickr-input[readonly]
     cursor pointer


### PR DESCRIPTION
allowInput controls the readonly attribute. When the user can manually edit the input field, it makes no sense to change the default input pointer as it remains fully functional.
Fixes #669