### PR TITLE
Allow timestamp of 0 to be included in selectedDates

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1435,7 +1435,7 @@ function Flatpickr(element, config) {
 		}
 
 		self.selectedDates = self.selectedDates.filter(
-			d => d instanceof Date && d.getTime() && isEnabled(d, false)
+			d => d instanceof Date && isEnabled(d, false)
 		);
 
 		self.selectedDates.sort((a,b) => a.getTime() - b.getTime());


### PR DESCRIPTION
The timestamp `0` refers to the date `1970-01-01`, which is a valid date.
Exluding timestamps of `0` stops the `onValueUpdate` hook from firing on
init if the date is `1970-01-01`.