### PR TITLE
Fixes TypeError on scroll

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1840,7 +1840,7 @@ function Flatpickr(element, config) {
 
 		let newValue = curValue + step * delta;
 
-		if (input.value.length === 2) {
+		if (typeof(input.value) !== "undefined" && input.value.length === 2) {
 			const isHourElem = input === self.hourElement,
 				isMinuteElem = input === self.minuteElement;
 


### PR DESCRIPTION
Fixes a TypeError which occurred when using the scroll wheel on elements other than the hour or minute input fields (e.g. up- and down arrow)

Fixes #682 