### PR TITLE
Fixed disabled issue when using altInput

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1095,7 +1095,7 @@ function Flatpickr(element, config) {
 			return;
 		}
 
-		if (self.isOpen || (self.altInput || self.input).disabled ||self.config.inline)
+		if (self.isOpen || (self.input || self.altInput).disabled ||self.config.inline)
 			return;
 		
 		self.isOpen = true;


### PR DESCRIPTION
This fixes the following bug.

  - Use the ```altInput``` flag in the configuration.
  - Disable the main input
  - The calendar will still open even though the main input is disabled.

The reason for this is simple. Your check for disabled input checks if the altInput exists and uses it over the main input for the disabled flag. This would work fine if the altInput would clone the disabled property from the main input, but it does not. Because of this, disabled inputs do not work when using the ```altInput = true``` flag. This fixes that problem.