### PR TITLE
Allow config to override firstDayOfWeek

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -470,7 +470,8 @@ function Flatpickr(element, config) {
 	}
 
 	function buildDays(year, month) {
-	    const firstDayOfWeek = self.instanceConfig.firstDayOfWeek || self.l10n.firstDayOfWeek;
+	    const firstDayOfWeek = (typeof self.instanceConfig.firstDayOfWeek === "number") ?
+            self.instanceConfig.firstDayOfWeek : self.l10n.firstDayOfWeek;
 		const firstOfMonth = (
 				new Date(self.currentYear, self.currentMonth, 1).getDay() -
                 firstDayOfWeek + 7
@@ -684,7 +685,8 @@ function Flatpickr(element, config) {
 		if (!self.weekdayContainer)
 			self.weekdayContainer = createElement("div", "flatpickr-weekdays");
 
-		const firstDayOfWeek = self.instanceConfig.firstDayOfWeek || self.l10n.firstDayOfWeek;
+        const firstDayOfWeek = (typeof self.instanceConfig.firstDayOfWeek === "number") ?
+            self.instanceConfig.firstDayOfWeek : self.l10n.firstDayOfWeek;
 		let	weekdays = self.l10n.weekdays.shorthand.slice();
 
 		if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -470,9 +470,10 @@ function Flatpickr(element, config) {
 	}
 
 	function buildDays(year, month) {
+	    const firstDayOfWeek = self.instanceConfig.firstDayOfWeek || self.l10n.firstDayOfWeek;
 		const firstOfMonth = (
 				new Date(self.currentYear, self.currentMonth, 1).getDay() -
-				self.l10n.firstDayOfWeek + 7
+                firstDayOfWeek + 7
 			) % 7,
 			isRangeMode = self.config.mode === "range";
 
@@ -683,7 +684,7 @@ function Flatpickr(element, config) {
 		if (!self.weekdayContainer)
 			self.weekdayContainer = createElement("div", "flatpickr-weekdays");
 
-		const firstDayOfWeek = self.l10n.firstDayOfWeek;
+		const firstDayOfWeek = self.instanceConfig.firstDayOfWeek || self.l10n.firstDayOfWeek;
 		let	weekdays = self.l10n.weekdays.shorthand.slice();
 
 		if (firstDayOfWeek > 0 && firstDayOfWeek < weekdays.length) {


### PR DESCRIPTION
**Use case**
Sometimes you may want to have the week start on a monday or on a sunday depending on business practices, independent from the actual locale. For example, in my company we want to use an English locale, but in some cases we want the first day of the week to be monday and not sunday. Since this is more of a preference in certain (areas of) businesses it seems logical to make it more easily configurable instead of only defining it in the localisation file, which is more "set in stone" for the entire locale. 

**Solution**
Just try to read firstDayOfWeek from the instanceConfig first and otherwise from the l10n.

**Tests**
All tests pass. Not sure if you want to add new tests for this functionality? It's just two lines, not very complex. 

Feedback is welcome! :)