### PR TITLE
Added clear date plugin

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1,4 +1,4 @@
-/*! flatpickr v2.4.7, @license MIT */
+/*! flatpickr v, @license MIT */
 function Flatpickr(element, config) {
 	const self = this;
 

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1,4 +1,4 @@
-/*! flatpickr v, @license MIT */
+/*! flatpickr v2.4.7, @license MIT */
 function Flatpickr(element, config) {
 	const self = this;
 

--- a/src/plugins/clearDate/clearDate.css
+++ b/src/plugins/clearDate/clearDate.css
@@ -1,0 +1,17 @@
+.flatpickr-clear {
+	height: 30px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	cursor: pointer;
+	background: rgba(0,0,0,0.06)
+}
+
+.flatpickr-clear .clear-icon {
+	margin-right: 5px;
+}
+
+.flatpickr-clear.darkTheme {
+	color: white;
+	fill: white;
+}

--- a/src/plugins/clearDate/clearDate.js
+++ b/src/plugins/clearDate/clearDate.js
@@ -1,0 +1,61 @@
+/**
+ * Flatpickr Clear Date Plugin.
+ *
+ * Adds a Clear button under the calendar which allows the user to clear the selected date.
+ *
+ * @author Mihai MATEI <mihai.matei@outlook.com>
+ * @license MIT
+ */
+
+/**
+ * Clear date plugin.
+ *
+ * @param {Object} pluginConfig
+ *
+ * @returns {Function}
+ */
+function clearDatePlugin(pluginConfig)
+{
+    var defaultConfig = {
+        clearIcon: '<i class="fa fa-remove clear-icon"></i>',
+        clearText: 'Clear',
+        triggerChangeEvent: true,
+        close: true,
+        theme: "light"
+    };
+
+    var config = {};
+    for (var key in defaultConfig) {
+        config[key] = pluginConfig && pluginConfig[key] !== undefined ? pluginConfig[key] : defaultConfig[key];
+    }
+
+    return function (fp)
+    {
+        fp.clearContainer = fp._createElement(
+            "div",
+            "flatpickr-clear " + config.theme + "Theme",
+            config.clearText
+        );
+
+        fp.clearContainer.tabIndex = -1;
+        fp.clearContainer.innerHTML = config.clearIcon + fp.clearContainer.innerHTML;
+
+        fp.clearContainer.addEventListener("click", function() {
+
+            fp.clear(config.triggerChangeEvent);
+
+            if (config.close) {
+                fp.close();
+            }
+        });
+
+        return {
+            onReady: function onReady() {
+                fp.calendarContainer.appendChild(fp.clearContainer);
+            }
+        };
+    };
+}
+
+if (typeof module !== "undefined")
+    module.exports = clearDatePlugin;


### PR DESCRIPTION
The plugin is similar to confirm date plugin.

It adds a Clear button under the calendar and lets the user clear the selected date by pressing it.

Plugin default configuration:

    {
        clearIcon: '<i class="fa fa-remove clear-icon"></i>',
        clearText: 'Clear',
        triggerChangeEvent: true,
        close: true,
        theme: "light"
    }

