### PR TITLE
Corrected capitalization for Dutch days and months

### DIFF
--- a/src/l10n/nl.js
+++ b/src/l10n/nl.js
@@ -3,13 +3,13 @@ var Flatpickr = Flatpickr||{l10ns: {}};
 Flatpickr.l10ns.nl = {};
 
 Flatpickr.l10ns.nl.weekdays = {
-	shorthand: ['Zo', 'Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za'],
-	longhand: ['Zondag', 'Maandag', 'Dinsdag', 'Woensdag', 'Donderdag', 'Vrijdag', 'Zaterdag']
+	shorthand: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
+	longhand: ['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag']
 };
 
 Flatpickr.l10ns.nl.months = {
-	shorthand: ['Jan', 'Feb', 'Maa', 'Apr', 'Mei', 'Jun', 'Jul', 'Aug', 'Sept', 'Okt', 'Nov', 'Dec'],
-	longhand: ['Januari', 'Februari', 'Maart', 'April', 'Mei', 'Juni', 'Juli', 'Augustus', 'September', 'Oktober', 'November', 'December']
+	shorthand: ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sept', 'okt', 'nov', 'dec'],
+	longhand: ['januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december']
 };
 
 Flatpickr.l10ns.nl.firstDayOfWeek = 1;


### PR DESCRIPTION
In Dutch, unlike in English, the names of days and months don't start with a capital letter. The only exception is when they're used as the first word in a sentence, but this doesn't apply to Flatpickr (the names of days/months are part of the UI, so not officially a sentence).

This PR corrects the capitalization for the Dutch translations and also fixes an incorrect abbreviation for the month March (should be "mrt", not "maa").