### PR TITLE
Fixed incorrect characters in Lithuanian translation

### DIFF
--- a/dist/l10n/lt.js
+++ b/dist/l10n/lt.js
@@ -9,7 +9,7 @@ Flatpickr.l10ns.lt.weekdays = {
 
 Flatpickr.l10ns.lt.months = {
 	shorthand: ['Sau', 'Vas', 'Kov', 'Bal', 'Geg', 'Bir', 'Lie', 'Rgp', 'Rgs', 'Spl', 'Lap', 'Grd'],
-	longhand: ['Sausis', 'Vasaris', 'Kovas', 'Balandis', 'Gegužȩ̇', 'Birņelis', 'Liepa', 'Rugpjūtis', 'Rugsėjis', 'Spalis', 'Lapkritis', 'Gruodis']
+	longhand: ['Sausis', 'Vasaris', 'Kovas', 'Balandis', 'Gegužė', 'Birželis', 'Liepa', 'Rugpjūtis', 'Rugsėjis', 'Spalis', 'Lapkritis', 'Gruodis']
 };
 
 Flatpickr.l10ns.lt.firstDayOfWeek = 1;


### PR DESCRIPTION
I fixed month names in Lithuanian translation. Somehow they have some characters that do not even exist in Lithuanian.