### PR TITLE
Add a changeDayAtMidnight option

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -2180,6 +2180,16 @@ function Flatpickr(element, config) {
 			)
 				self.amPM.textContent = self.amPM.textContent === "PM" ? "AM" : "PM";
 
+      if (self.config.changeDayAtMidnight && isHourElem) {
+        if (curValue === 23 && newValue === 0) {
+          self.selectedDates[0].setDate(self.selectedDates[0].getDate() + 1);
+          self.redraw();
+        }
+        else if (curValue === 0 && newValue === 23) {
+          self.selectedDates[0].setDate(self.selectedDates[0].getDate() - 1);
+          self.redraw();
+        }
+      }
 
 			input.value = self.pad(newValue);
 		}
@@ -2221,6 +2231,9 @@ Flatpickr.defaultConfig = {
 
 	// enables the time picker functionality
 	enableTime: false,
+  
+  // if true, wrapping the time at midnight will change the day
+  changeDayAtMidnight: false,
 
 	// noCalendar: true will hide the calendar. use for a time picker along w/ enableTime
 	noCalendar: false,


### PR DESCRIPTION
When enableTime is on, and the user increments/decrements the hour selector past midnight, the normal behaviour is that the date doesn't change.

This PR adds an option called `changeDayAtMidnight` that also increments or decrements the date when the user moves past midnight in either direction, which is the expected behaviour for a lot of applications.

I haven't added any tests but please shout if you need them and I'll try to add them in.