### PR TITLE
Change day at midnight (plugin version)

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -165,6 +165,12 @@ function Flatpickr(element, config) {
 	 * @param {Number} seconds the seconds (optional)
 	 */
 	function setHours(hours, minutes, seconds) {
+		var old = {
+			"oldHours": self.latestSelectedDateObj.getHours(),
+			"oldMinutes": self.latestSelectedDateObj.getMinutes(),
+			"oldSeconds": self.latestSelectedDateObj.getSeconds()
+		};
+
 		if (self.selectedDates.length) {
 			self.latestSelectedDateObj.setHours(
 				hours % 24, minutes, seconds || 0, 0
@@ -187,6 +193,8 @@ function Flatpickr(element, config) {
 
 		if (self.config.enableSeconds === true)
 			self.secondElement.value = self.pad(seconds);
+
+		triggerEvent("TimeChange", old);
 	}
 
 	/**
@@ -1423,7 +1431,8 @@ function Flatpickr(element, config) {
 
 		let hooks = [
 			"onChange", "onClose", "onDayCreate", "onKeyDown", "onMonthChange",
-			"onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange"
+			"onOpen", "onParseConfig", "onReady", "onValueUpdate", "onYearChange",
+			"onTimeChange"
 		];
 
 		self.config = Object.create(flatpickr.defaultConfig);
@@ -2649,6 +2658,9 @@ flatpickr.defaultConfig = Flatpickr.defaultConfig = {
 
 	// called every time the month is changed
 	onMonthChange: undefined,
+
+	// called every time the time is changed
+	onTimeChange: undefined,
 
 	// called every time calendar is opened
 	onOpen: undefined, // function (dateObj, dateStr) {}

--- a/src/plugins/changeDayAtMidnight/changeDayAtMidnight.js
+++ b/src/plugins/changeDayAtMidnight/changeDayAtMidnight.js
@@ -1,24 +1,15 @@
 function changeDayAtMidnightPlugin() {
-  var lastSeenHour;
 
-  function setLSH(date) {
-    if (date !== undefined) {
-      lastSeenHour = date.getHours();
-    } else {
-      lastSeenHour = undefined;
-    }
-  }
-
-  function changeDateIfMidnight(date, fp) {
-    var newHour = date.getHours();
+  function changeDateIfMidnight(date, ev, fp) {
+    var newHours = date.getHours();
 
     // Clock has advanced past the end of the day - advance the date
-    if (newHour == 0 && lastSeenHour == 23) {
+    if (newHours == 0 && ev.oldHours == 23) {
       date.setDate(date.getDate() + 1);
       fp.setDate(date, false);
     }
     // Clock has gone back past the start of the day - take the date back
-    else if (newHour == 23 && lastSeenHour == 0) {
+    else if (newHours == 23 && ev.oldHours == 0) {
       date.setDate(date.getDate() - 1);
       fp.setDate(date, false);
     }
@@ -27,12 +18,8 @@ function changeDayAtMidnightPlugin() {
 
   return function(fp) {
     return {
-      onReady(dates) {
-        setLSH(dates[0]);
-      },
-      onChange(dates) {
-        changeDateIfMidnight(dates[0], fp);
-        setLSH(dates[0]);
+      onTimeChange(dates, _, __, ev) {
+        changeDateIfMidnight(dates[0], ev, fp);
       }
     }
   }

--- a/src/plugins/changeDayAtMidnight/changeDayAtMidnight.js
+++ b/src/plugins/changeDayAtMidnight/changeDayAtMidnight.js
@@ -1,0 +1,42 @@
+function changeDayAtMidnightPlugin() {
+  var lastSeenHour;
+
+  function setLSH(date) {
+    if (date !== undefined) {
+      lastSeenHour = date.getHours();
+    } else {
+      lastSeenHour = undefined;
+    }
+  }
+
+  function changeDateIfMidnight(date, fp) {
+    var newHour = date.getHours();
+
+    // Clock has advanced past the end of the day - advance the date
+    if (newHour == 0 && lastSeenHour == 23) {
+      date.setDate(date.getDate() + 1);
+      fp.setDate(date, false);
+    }
+    // Clock has gone back past the start of the day - take the date back
+    else if (newHour == 23 && lastSeenHour == 0) {
+      date.setDate(date.getDate() - 1);
+      fp.setDate(date, false);
+    }
+
+  }
+
+  return function(fp) {
+    return {
+      onReady(dates) {
+        setLSH(dates[0]);
+      },
+      onChange(dates) {
+        changeDateIfMidnight(dates[0], fp);
+        setLSH(dates[0]);
+      }
+    }
+  }
+}
+
+if (typeof module !== "undefined")
+	module.exports = changeDayAtMidnightPlugin;


### PR DESCRIPTION
Hi @chmln - thanks for your comments on #783 about this functionality being implemented as a plugin.

Unfortunately, it couldn't be done in an `onChange` handler because of a race condition - we didn't know what the "old" value was so we couldn't tell if the hour selector had been advanced past midnight. Storing the old value in a global variable doesn't work because if the user is quick enough at clicking the arrow, the two values race with each other.

This implementation moves all of the changeDayAtMidnight functionality to a plugin, but it depends on a new event `onTimeChange` that is called whenever the time changes, with the old value in the `data` object.

I hope this is a less invasive approach and you're happy to accept this version upstream! Please let me know if you have any questions.