### PR TITLE
Update da.js

### DIFF
--- a/dist/l10n/da.js
+++ b/dist/l10n/da.js
@@ -12,6 +12,8 @@ flatpickr.l10ns.da.months = {
 	longhand: ["Januar", "Februar", "Marts", "April", "Maj", "Juni", "Juli", "August", "September", "Oktober", "November", "December"]
 };
 
+flatpickr.l10ns.da.firstDayOfWeek = 1; // Set it to monday (Mandag)
+
 flatpickr.l10ns.da.ordinal = function () {
 	return ".";
 };


### PR DESCRIPTION
The `firstDayOfWeek` option should be set to `1` as default, since Monday/Mandag is the starting week day in Denmark.