### PR TITLE
Add touchstart event listeners

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -234,7 +234,8 @@ function Flatpickr(element, config) {
 		return evt => {
 			if (window.ontouchstart !== undefined) {
 				if (evt.type !== "touchstart") return;
-			} else if (evt.which !== 1) return;
+			}
+			else if (evt.which !== 1) return;
 
 			return handler(evt);
 		}


### PR DESCRIPTION
Included into existing mousedown method with checking if there is supposed to be touch event - ignore mousedown ones.

The issue with touch events only reproducible on ios via webview. In mobile safari all works well, probably there is some different emulation of mousedown event.