### PR TITLE
Use visibility instead of display for showing/hiding calendar pickers

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -771,7 +771,7 @@ function FlatpickrInstance(element, config) {
 			},
 			set (bool) {
 				if (this.__hidePrevMonthArrow !== bool)
-					self.prevMonthNav.style.display = bool ? "none" : "block";
+					self.prevMonthNav.style.visibility = bool ? "visible" : "hidden";
 				this.__hidePrevMonthArrow = bool;
 			}
 		});
@@ -782,7 +782,7 @@ function FlatpickrInstance(element, config) {
 			},
 			set (bool) {
 				if (this.__hideNextMonthArrow !== bool)
-					self.nextMonthNav.style.display = bool ? "none" : "block";
+					self.nextMonthNav.style.visibility = bool ? "visible" : "hidden";
 				this.__hideNextMonthArrow = bool;
 			}
 		});


### PR DESCRIPTION
This makes it so that custom css display (e.g. display:flex) is not overridden.