### PR TITLE
Basic support for server-side-rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "nodemon --watch build.js build.js -- --dev",
     "build": "node build.js",
     "lint": "eslint src/",
-    "test": "npm run lint && jest --bail",
+    "test": "npm run lint && jest --bail && npm run test-ssr",
+    "test-ssr": "node -e 'require(\"./src/flatpickr.js\")'",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "release": "jest --bail --silent && ./release"
   },

--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -2572,7 +2572,7 @@ flatpickr.defaultConfig = FlatpickrInstance.defaultConfig = {
 
 	position: "auto",
 
-	animate: window.navigator.userAgent.indexOf("MSIE") === -1,
+	animate: typeof window !== "undefined" && window.navigator.userAgent.indexOf("MSIE") === -1,
 
 	// wrap: see https://chmln.github.io/flatpickr/examples/#flatpickr-external-elements
 	wrap: false,


### PR DESCRIPTION
This checks if `window` exists before checking `window.navigator` when creating the default config.

Without this check, Flatpickr cannot even be loaded in Node.js (for e.g. server-side-rendering of the react component).

This has a side-effect of disabling animation in Node.js :P

I also added a very simple test that just runs `require('require('./src/flatpickr.js')` in Node.js. A more comprehensive test might be to build the dist folder and then require `dist/flatpickr.js`, I can switch it if you'd prefer. Note that this test must run outside of Jest, because Jest automatically pollyfills `window`, which would make it pass even when it shouldn't.

This fixes the root cause of the following issues:
* https://github.com/coderhaoxin/react-flatpickr/issues/9
* https://github.com/carbon-design-system/carbon-components-react/issues/76