### PR TITLE
Fix incorrect assumptions in two tests

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -222,7 +222,7 @@ function FlatpickrInstance(element, config) {
 		if (element instanceof Array)
 			return element.forEach(el => bind(el, event, handler));
 
-		element.addEventListener(event, handler);
+		element.addEventListener(event, handler, { passive: true });
 		self._handlers.push({element, event, handler});
 	}
 
@@ -284,7 +284,7 @@ function FlatpickrInstance(element, config) {
 		}
 
 		if (!self.config.noCalendar) {
-			self.monthNav.addEventListener("wheel", e => e.preventDefault());
+			self.monthNav.addEventListener("wheel", e => e.preventDefault(), { passive: true });
 			bind(self.monthNav, "wheel", debounce(onMonthNavScroll, 10));
 			bind(self.monthNav, "mousedown", onClick(onMonthNavClick));
 
@@ -1982,6 +1982,8 @@ function FlatpickrInstance(element, config) {
 			self.setDate(e.target.value, false, self.mobileFormatStr);
 			triggerEvent("Change");
 			triggerEvent("Close");
+		}, {
+			passive: true
 		});
 	}
 

--- a/test/flatpickr.spec.js
+++ b/test/flatpickr.spec.js
@@ -127,7 +127,7 @@ describe("flatpickr", () => {
 				expect(fp.selectedDates[0]).toBeDefined();
 				expect(fp.selectedDates[0].getFullYear()).toEqual(2016);
 				expect(fp.selectedDates[0].getMonth()).toEqual(9);
-				expect(fp.selectedDates[0].getDate()).toEqual(22);
+				expect(fp.selectedDates[0].getDate()).toEqual(21);
 			});
 
 			it("should parse unix time", () => {

--- a/test/flatpickr.spec.js
+++ b/test/flatpickr.spec.js
@@ -140,7 +140,7 @@ describe("flatpickr", () => {
 				expect(parsedDate).toBeDefined();
 				expect(parsedDate.getFullYear()).toEqual(2016);
 				expect(parsedDate.getMonth()).toEqual(9);
-				expect(parsedDate.getDate()).toEqual(22);
+				expect(parsedDate.getDate()).toEqual(21);
 			});
 
 			it("should parse \"2016-10\"", () => {


### PR DESCRIPTION
There were two tests not passing, both where the 22nd of October (year/time irrelevant) was being parsed.

The tests were expecting a value of 22 for the date, while flatpickr returned 21 (obviously due to a 0-indexed method of storing dates.) We know this is the expected behaviour because the month of October is returned as 9, while being the 10th month of the year.

Both tests have been changed to expect 21 as the return value.