### PR TITLE
Fixed `parseDateRules` method

### DIFF
--- a/src/flatpickr.js
+++ b/src/flatpickr.js
@@ -1789,17 +1789,19 @@ function FlatpickrInstance(element, config) {
 	}
 
 	function parseDateRules(arr) {
-		for (let i = arr.length; i--;) {
-			if (typeof arr[i] === "string" || +arr[i])
-				arr[i] = self.parseDate(arr[i], null, true);
+		const rules = arr.slice();
 
-			else if (arr[i] && arr[i].from && arr[i].to) {
-				arr[i].from = self.parseDate(arr[i].from);
-				arr[i].to = self.parseDate(arr[i].to);
+		for (let i = rules.length; i--;) {
+			if (typeof rules[i] === "string" || +rules[i])
+				rules[i] = self.parseDate(rules[i], null, true);
+
+			else if (rules[i] && rules[i].from && rules[i].to) {
+				rules[i].from = self.parseDate(rules[i].from);
+				rules[i].to = self.parseDate(rules[i].to);
 			}
 		}
 
-		return arr.filter(x => x); // remove falsy values
+		return rules.filter(x => x); // remove falsy values
 	}
 
 	function setupDates() {

--- a/test/flatpickr.spec.js
+++ b/test/flatpickr.spec.js
@@ -1089,6 +1089,38 @@ describe("flatpickr", () => {
 		});
 	});
 
+	describe("Other", () => {
+		it("does not change the value of the passed enable[] and disable[] variables", () => {
+			let data = [
+				{from: "2016-11-20", to: "2016-12-20"},
+				"2016-12-21",
+				null
+			], copiedData = data.slice();
+
+			createInstance({
+				disable: data
+			});
+
+			expect(data).toEqual(copiedData);
+
+			fp.set("disable", []);
+			fp.clear();
+
+			data = [
+				{from: "2016-11-20", to: "2016-12-20"},
+				"2016-12-21",
+				null
+			];
+			copiedData = data.slice();
+
+			createInstance({
+				disable: data
+			});
+
+			expect(data).toEqual(copiedData);
+		});
+	});
+
 	// afterAll(() => {
 	// 	fp.destroy();
 	// 	elem.parentNode.removeChild(elem);


### PR DESCRIPTION
Fixed modification of passed params. Previous behavior:
```
Expected value to equal:
  [{"from": 2016-11-19T21:00:00.000Z, "to": 2016-12-19T21:00:00.000Z}, "2016-12-21", null]
Received:
  [{"from": 2016-11-19T21:00:00.000Z, "to": 2016-12-19T21:00:00.000Z}, 2016-12-20T21:00:00.000Z, null]

Difference:

- Expected
+ Received

 Array [
   Object {
     "from": 2016-11-19T21:00:00.000Z,
     "to": 2016-12-19T21:00:00.000Z,
   },
-  "2016-12-21",
+  2016-12-20T21:00:00.000Z,
   null,
 ]
```

Suggested behavior: passed params must not be changed.