### PR TITLE
Fix confirmDate plugin config options

### DIFF
--- a/src/plugins/confirmDate/confirmDate.ts
+++ b/src/plugins/confirmDate/confirmDate.ts
@@ -16,7 +16,7 @@ const defaultConfig: Config = {
 };
 
 function confirmDatePlugin(pluginConfig: Config) {
-  const config = { ...defaultConfig, pluginConfig };
+  const config = { ...defaultConfig, ...pluginConfig };
   let confirmContainer: HTMLDivElement;
 
   return function(fp: Instance) {


### PR DESCRIPTION
This looks like a typo. Instead of passing a property called `pluginConfig`, we need to inline the user's config options into `config`.

EDIT: Sorry, I accidentally submitted without going through CONTRIBUTING.md. Reading now, will update this for compliance.

EDIT 2: I can't easily show a fiddle demonstrating the bug, as the code with the bug hasn't been released yet. I found this bug because I inlined `dist/plugins/confirmDate/confirmDate.js` into my own project to test some modifications, and realised my config options weren't having any effect.