### PR TITLE
fix mouseDelta function

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -412,6 +412,19 @@ describe("flatpickr", () => {
       expect(fp.currentMonth).toEqual(2);
     });
 
+    it("monthScroll: 0 < abs(delta) < 1", () => {
+      createInstance();
+      fp.changeMonth(1, false);
+
+      fp.open();
+      simulate("wheel", fp.currentMonthElement, {
+        deltaY: -0.3,
+      });
+
+      jest.runAllTimers();
+      expect(fp.currentMonth).toEqual(2);
+    });
+
     it("yearScroll", () => {
       createInstance();
       const now = new Date();

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,7 +23,9 @@ export function debounce<F extends Function>(
 export const arrayify = <T>(obj: T | T[]): T[] =>
   obj instanceof Array ? obj : [obj];
 
-export const mouseDelta = (e: MouseWheelEvent) =>
-  Math.max(-1, Math.min(1, e.wheelDelta || -e.deltaY));
+export function mouseDelta(e: MouseWheelEvent): number {
+  const delta = e.wheelDelta || -e.deltaY;
+  return delta >= 0 ? 1 : -1;
+}
 
 export type IncrementEvent = MouseEvent & { delta: number; type: "increment" };


### PR DESCRIPTION
Like I described in https://github.com/chmln/flatpickr/issues/734, with a specific set of conditions (Windows, Firefox and scrolling with a trackpad), delta values from the `wheel` event can be between -1 and 1, resulting in bogus increments of years or months.