### PR TITLE
add missing spaces to options/index.html

### DIFF
--- a/options/index.html
+++ b/options/index.html
@@ -679,7 +679,7 @@
             <td>static</td>
             <td>boolean</td>
             <td>false</td>
-            <td>Position the calendar inside the wrapper and next to the input element. (Leave<code>false</code>unless you know what you're doing.</td>
+            <td>Position the calendar inside the wrapper and next to the input element. (Leave <code>false</code> unless you know what you're doing.</td>
         </tr>
         <tr>
             <td>time_24hr</td>


### PR DESCRIPTION
Add missing spaces in the _warning_ on the `Static` options details