### PR TITLE
fixes labelPlugin on mobile

### DIFF
--- a/src/plugins/labelPlugin/labelPlugin.ts
+++ b/src/plugins/labelPlugin/labelPlugin.ts
@@ -5,7 +5,15 @@ function labelPlugin() {
     return {
       onReady() {
         const id = fp.input.id;
-        if (fp.altInput && id) {
+
+        if (!id) {
+          return;
+        }
+
+        if (fp.mobileInput) {
+          fp.input.removeAttribute("id");
+          fp.mobileInput.id = id;
+        } else if (fp.altInput) {
           fp.input.removeAttribute("id");
           fp.altInput.id = id;
         }


### PR DESCRIPTION
Label plugin doesn't work on mobile devices. Label click (touch) doesn't open datepicker.
There is fiddle with current version and fixed one. 
[https://embed.plnkr.co/0kJLFhiv0lXuzQsdINLN/](https://embed.plnkr.co/0kJLFhiv0lXuzQsdINLN/)

