### PR TITLE
Add basic server-side rendering support

### DIFF
--- a/.jest.ssr.json
+++ b/.jest.ssr.json
@@ -1,0 +1,16 @@
+{
+  "bail": true,
+  "transform": {
+    "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+  },
+  "testEnvironment": "node",
+  "testRegex": "(/__ssr_tests__/.*|(\\.|/)(test|spec)\\.ssr)\\.(jsx?|tsx?)$",
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json"
+  ],
+  "moduleDirectories": ["src", "node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "start": "npm run build:build -- --dev",
     "rollup:start": "rollup -w -c",
     "rollup:build": "rollup -c",
-    "test": "run-s test:typecheck test:unit",
+    "test": "run-s test:typecheck test:unit test:ssr",
     "test:typecheck": "tsc -p ./ --noEmit",
     "test:unit": "jest --config .jest.json",
+    "test:ssr": "jest --config .jest.ssr.json",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "precommit": "lint-staged --silent"
   },

--- a/src/__ssr_tests__/index.spec.ssr.ts
+++ b/src/__ssr_tests__/index.spec.ssr.ts
@@ -1,0 +1,7 @@
+import flatpickr from "index";
+
+describe("flatpickr SSR", () => {
+  it("can be imported", () => {
+    expect(typeof flatpickr).toEqual("function");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2599,7 +2599,7 @@ flatpickr = function(
   return _flatpickr([selector], config);
 } as FlatpickrFn;
 
-window.flatpickr = flatpickr;
+if (typeof window === "object") window.flatpickr = flatpickr;
 
 /* istanbul ignore next */
 flatpickr.defaultConfig = defaultOptions;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -282,7 +282,9 @@ export const defaults: ParsedOptions = {
   altFormat: "F j, Y",
   altInput: false,
   altInputClass: "form-control input",
-  animate: window && window.navigator.userAgent.indexOf("MSIE") === -1,
+  animate:
+    typeof window === "object" &&
+    window.navigator.userAgent.indexOf("MSIE") === -1,
   ariaDateFormat: "F j, Y",
   clickOpens: true,
   closeOnSelect: true,


### PR DESCRIPTION
The switch to typescript seems to have caused a regression from the changes in #969. This adds a very simple SSR test, while also setting up a framework for adding more, which will automatically get run with the other tests.