### PR TITLE
Typing : export all options type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { FlatpickrFn } from "./src/types/instance";
 export { Instance } from "./src/types/instance";
-export { Options, Plugin } from "./src/types/options";
+export * from "./src/types/options";
 
 declare var flatpickr: FlatpickrFn;
 


### PR DESCRIPTION
Useful when we need for example to do :
```ts
import { Hook } from 'flatpickr';
```