### PR TITLE
Daylight Savings Causes Range Style Issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1584,11 +1584,16 @@ function FlatpickrInstance(
     }
 
     for (
-      let timestamp = (self.days.childNodes[0] as DayElement).dateObj.getTime(),
-        i = 0;
+      let i = 0;
       i < 42;
-      i++, timestamp += duration.DAY
+      i++
     ) {
+	
+	  let d = (self.days.childNodes[0] as DayElement).dateObj;
+	  d.setDate(d.getDate() + i);
+			 
+	  let timestamp = d.getTime();
+			 
       const outOfRange =
           timestamp < self.minRangeDate.getTime() ||
           timestamp > self.maxRangeDate.getTime(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1589,7 +1589,7 @@ function FlatpickrInstance(
       i++
     ) {
 	
-	  let d = (self.days.childNodes[0] as DayElement).dateObj;
+	  let d = new Date((self.days.childNodes[0] as DayElement).dateObj);
 	  d.setDate(d.getDate() + i);
 			 
 	  let timestamp = d.getTime();


### PR DESCRIPTION
This fixes an issue where if the flatpickr is in range mode and the user selects the first date on a month where daylight savings time start or end and the selected date is after the date on which DST changes, the styles are not properly applied to the selected date.

Link to detailed issue: https://github.com/chmln/flatpickr/issues/1106