### PR TITLE
Add noImplicitAny option in tsconfig (#1120)

### DIFF
--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -27,7 +27,7 @@ export type token =
   | "w"
   | "y";
 
-const do_nothing = () => undefined;
+const do_nothing = (): void => undefined;
 
 export type RevFormatFn = (
   date: Date,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "strictFunctionTypes": true,
+    "noImplicitAny": true,
     "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
This PR will add the noImplicitAny option into tsconfig.json file (#1120).

I had to disable this option in my project because when compiling flatpickr module, tsc gave me this error:

_./node_modules/flatpickr/src/utils/formatting.ts at line 30_
Function expression, which lacks return-type annotation, implicitly has an 'any' return type.