### PR TITLE
fix "no implicit any" error in utils/formatting

### DIFF
--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -27,7 +27,7 @@ export type token =
   | "w"
   | "y";
 
-const do_nothing = (): void => undefined;
+const do_nothing = (): undefined => undefined;
 
 export type RevFormatFn = (
   date: Date,


### PR DESCRIPTION
This just defines the return type for the `do_nothing` arrow function to avoid "no implicit any" errors in dependent apps.