### PR TITLE
Emit custom events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2403,11 +2403,23 @@ function FlatpickrInstance(
       // many front-end frameworks bind to the input event
       self.input.dispatchEvent(createEvent("input"));
     }
+
+    self.input.dispatchEvent(createCustomEvent(event, {
+      selectedDates: self.selectedDates,
+      dateStr: self.input.value,
+      instance: self
+    }))
   }
 
   function createEvent(name: string): Event {
     const e = document.createEvent("Event");
     e.initEvent(name, true, true);
+    return e;
+  }
+
+  function createCustomEvent(name: string, data: Object): Event {
+    const e = document.createEvent("CustomEvent");
+    e.initCustomEvent(name, true, true, data);
     return e;
   }
 


### PR DESCRIPTION
Hi,

In order to hook into various events in flatpickr we have to pass methods in config.

This PR enables another way to hook into them.
```html
<input type="text" id="datepickr">
<script>
var input = document.querySelector("#datepickr");
var fp = flatpickr(input,{})

input.addEventListener("onChange", function(e) {
    console.log(e.detail.selectedDates);
    console.log(e.detail.dateStr);
    console.log(e.detail.instance);
});
</script>
```
Similarly we can hook rest of [events](https://chmln.github.io/flatpickr/events/)

[Custom events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) has wide [support](https://caniuse.com/#feat=customevent) in browsers. I also kept IE9 + [compatibility](https://stackoverflow.com/questions/19345392/why-arent-my-parameters-getting-passed-through-to-a-dispatched-event).
