### PR TITLE
Calculate opened picker position when initializing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ function FlatpickrInstance(
         self.daysContainer.offsetWidth + self.weekWrapper.offsetWidth + "px";
     }
 
-    if (!self.isMobile) positionCalendar();
+    if (!self.isMobile && self.isOpen) positionCalendar();
 
     triggerEvent("onReady");
   }


### PR DESCRIPTION
This fix is related to issue #1096 . There is no need to calculate the position of the picker when initializing it if it is not opened yet.