### PR TITLE
Call parseConfig() after mass config update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2128,8 +2128,10 @@ function FlatpickrInstance(
     option: keyof Options | { [k in keyof Options]?: Options[k] },
     value?: any
   ) {
-    if (option !== null && typeof option === "object")
+    if (option !== null && typeof option === "object"){
       Object.assign(self.config, option);
+      parseConfig();
+    }
     else self.config[option] = value;
 
     self.redraw();


### PR DESCRIPTION
Hi,
`flatpickr.set()` method accepts objects and allows mass updates to configs.
I noticed that some configs may gets lost during this process.
For example: [fiddle](https://jsfiddle.net/drwvxa0c/3/)
```html
<h3>Flatpickr v4.x plain js example</h3>
<main id="app">
  <button id="update">
  Update configs
  </button>
  <br> <br>
  <input type='text' id="flatpickr" />
</main>

```
```js
// init flatpicker
const configs = {
 onChange: function(selectedDates, dateStr, instance) {
    console.log('onChange hook: ', selectedDates);
  }
};

var fp = flatpickr(document.querySelector('#flatpickr'),configs);

document.querySelector("#update").addEventListener("click",function() {
  console.log("Update configs")
  configs.mode = 'multiple';
 // passing whole config again
  fp.set(configs)
  console.log(fp.config.onChange)
  // no longer array
  console.log(fp.config.onChange instanceof Array)
})
```
One options is not allow updating these hooks dynamically, or `arrayify` them before merging
