### PR TITLE
Update documentation for new Z Format Token

### DIFF
--- a/content/formatting.md
+++ b/content/formatting.md
@@ -83,6 +83,11 @@ Each character in the table below can be used in `dateFormat` and `altFormat` op
 <td>A full numeric representation of a year, 4 digits</td>
 <td>1999 or 2003</td>
 </tr>
+<tr>
+<td>Z</td>
+<td>ISO Date format</td>
+<td>2017-03-04T01:23:43.000Z</td>
+</tr>
 </tbody>
 </table>
 
@@ -129,3 +134,13 @@ Each character in the table below can be used in `dateFormat` and `altFormat` op
 </tr>
 </tbody>
 </table>
+
+## Escaping Formatting Tokens
+
+You may escape formatting tokens using `\\`.
+
+```js
+{
+    dateFormat: "Y-m-d\\Z", // Displays: 2017-01-22Z
+}
+```

--- a/content/updating-from-v2.md
+++ b/content/updating-from-v2.md
@@ -9,16 +9,18 @@ Breaking changes in flatpickr v3 have been kept to a minimum to ensure an easy u
 ## Deprecation of the utc option
 
 ### Motivation
+
 The `utc` option was a hack using date manipulation.
 <br>It didn't yield the correct timezone.
 <br>Resulting dates were not always accurate.
 
 ### Upgrade path
+
 Use the `dateFormat: "Z"` option, which is a shortcut for the ISO date format.
 <br>It contains the correct timezone information and is supported by nearly every database.
 
 Additionally I recommend using the `altInput: true` option to display a nicer date to the user.
-
+<br>Any existing date formats using a `Z` must be escaped `dateFormat: "dHi\\Z M y"`.
 
 ## Simplified invocation
 
@@ -39,6 +41,3 @@ For those using `flatpickr` with `<script src=".../flatpickr.js"...` - only a si
 
 Note that this also includes statements like `Flatpickr.defaultConfig...`.
 <br>Just swap out `Flatpickr` for `flatpickr` and you're good to go.
-
-
-


### PR DESCRIPTION
* Document Z format token: https://github.com/chmln/flatpickr/issues/952
* Document escaping format tokens
* Document if upgrading from v2 that existing Z tokens will need to be escaped

The bottom 2 bullet points we came across during our upgrade. I can open issues for them if you like but I thought it would be easier to just put them in a PR