### PR TITLE
fix: add `dist`-folder to tsconfig.json; correct typo in `lib`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,3 @@
 !src/style/**/*
 dist/index.d.ts
 !index.d.ts
-!tsconfig.json

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "removeComments": true,
     "types": ["jquery", "jest"],
     "lib": [
-      "ES2015",
+      "es2015",
       "dom",
       "es2017.object",
       "esnext.asynciterable"
@@ -20,6 +20,7 @@
     "baseUrl": "src"
   },
   "include": [
-    "./src"
+    "./src",
+    "./dist"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
     "baseUrl": "src"
   },
   "include": [
-    "./src",
-    "./dist"
+    "./src"
   ]
 }


### PR DESCRIPTION
when installing flatpickr via npm, all the ts-files in `src` do not exist. this leads to a ts-error.
fixes https://github.com/chmln/flatpickr/issues/1210