### PR TITLE
Fix flatpickr not closing after choosing date in IE11

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1844,7 +1844,11 @@ function FlatpickrInstance(
   function focusAndClose() {
     self._input.focus();
 
-    if (window.navigator.userAgent.indexOf("MSIE") === -1) self.close();
+    const isIE11 =
+      !!window.MSInputMethodContext && !!window.document.documentMode;
+
+    if (window.navigator.userAgent.indexOf("MSIE") === -1 && !isIE11)
+      self.close();
     else setTimeout(self.close, 0); // hack - bugs in IE focus handling keeps the calendar open
   }
 

--- a/src/types/globals.ts
+++ b/src/types/globals.ts
@@ -27,6 +27,11 @@ declare global {
 
   interface Window {
     flatpickr: FlatpickrFn;
+    MSInputMethodContext?: any;
+  }
+
+  interface Document {
+    documentMode?: any;
   }
 
   interface Date {


### PR DESCRIPTION
Fixes #1233 

Originally thought I was fixing #900, but that seems to be a completely separate issue that I'm not experiencing.

Tested on BrowserStack in IE10, IE11, IE10 Metro, IE11 Metro, and Edge (16).