### PR TITLE
Fix header month/year being clipped in IE11

### DIFF
--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -385,7 +385,7 @@
         font-family inherit
         font-weight 300
         line-height inherit
-        height initial
+        height auto
         border 0
         border-radius 0
         vertical-align initial


### PR DESCRIPTION
Fixes #1234 