### PR TITLE
Always `preventDefault()` event in `onMonthNavClick`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2337,17 +2337,20 @@ function FlatpickrInstance(
   }
 
   function onMonthNavClick(e: MouseEvent) {
+    e.preventDefault();
+
     const isPrevMonth = self.prevMonthNav.contains(e.target as Node);
     const isNextMonth = self.nextMonthNav.contains(e.target as Node);
 
-    if (isPrevMonth || isNextMonth) changeMonth(isPrevMonth ? -1 : 1);
-    else if (e.target === self.currentYearElement) {
-      e.preventDefault();
+    if (isPrevMonth || isNextMonth) {
+      changeMonth(isPrevMonth ? -1 : 1);
+    } else if (e.target === self.currentYearElement) {
       self.currentYearElement.select();
-    } else if ((e.target as Element).className === "arrowUp")
+    } else if ((e.target as Element).className === "arrowUp") {
       self.changeYear(self.currentYear + 1);
-    else if ((e.target as Element).className === "arrowDown")
+    } else if ((e.target as Element).className === "arrowDown") {
       self.changeYear(self.currentYear - 1);
+    }
   }
 
   function timeWrapper(e: MouseEvent | KeyboardEvent | IncrementEvent): void {


### PR DESCRIPTION
By always preventing the default event in `onMonthNavClick` no unwanted focus events get handled which caused faltpicker to immediately close in e.g. a BS modal.

This closes #1190.