### PR TITLE
altInput accessibility: use tabIndex from the original input element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2164,6 +2164,7 @@ function FlatpickrInstance(
       self.altInput.placeholder = self.input.placeholder;
       self.altInput.disabled = self.input.disabled;
       self.altInput.required = self.input.required;
+      self.altInput.tabIndex = self.input.tabIndex;
       self.altInput.type = "text";
       self.input.type = "hidden";
 


### PR DESCRIPTION
When using altInput, the new input field has no tabindex attribute, which can disrupt the order of focus of the element in a formular.
This change copies the original value to the alternative input element.