### PR TITLE
Fix for calendar not showing when calendarWeeks: true

### DIFF
--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -20,7 +20,6 @@
   animation none
   direction ltr
   border 0
-  display none
   font-size 14px
   line-height 24px
   border-radius 5px


### PR DESCRIPTION
Starting 4.3.0 the calendar popup is not showing when calendarWeeks: true
After a diff of https://cdn.jsdelivr.net/npm/flatpickr@4.3.0/dist/flatpickr.min.css and https://cdn.jsdelivr.net/npm/flatpickr@4.2.0/dist/flatpickr.min.css I found that .flatpickr-calendar is set to display: none; After removing this, the calendar opens just fine again. All other changes in 4.3.0 seem to have no affect on this.

Example for the code working with 4.2.0: https://jsfiddle.net/5Lkc5w5o/
Example for the code failing with 4.3.0: https://jsfiddle.net/5Lkc5w5o/1/
(Also failing on the examples page: https://chmln.github.io/flatpickr/examples/ )

My assumption of this one line change (remove display none) is that this will lead to the flatpickr.min.css also losing the display:none; line (as I do not know the [assumed] stylus syntax)