### PR TITLE
Use ISO 639-1 for Catalan locale

### DIFF
--- a/src/l10n/cat.ts
+++ b/src/l10n/cat.ts
@@ -75,6 +75,6 @@ export const Catalan: CustomLocale = {
   time_24hr: true,
 };
 
-fp.l10ns.cat = Catalan;
+fp.l10ns.cat = fp.l10ns.ca = Catalan;
 
 export default fp.l10ns;

--- a/src/l10n/index.ts
+++ b/src/l10n/index.ts
@@ -69,6 +69,7 @@ const l10n: Record<key, CustomLocale> = {
   bg,
   bn,
   bs,
+  ca: cat,
   cat,
   cs,
   cy,

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -118,6 +118,7 @@ export type key =
   | "bg"
   | "bn"
   | "bs"
+  | "ca"
   | "cat"
   | "cs"
   | "cy"


### PR DESCRIPTION
Adds `ca` as an alias of the Catalan locale (`cat`) so all languages follow the ISO 639-1 format, without breaking any backwards compatibility.

Closes #2155 