### PR TITLE
Update Event.path into Event.composedPath()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1462,10 +1462,10 @@ function FlatpickrInstance(
         self.element.contains(eventTarget as HTMLElement) ||
         // web components
         // e.path is not present in all browsers. circumventing typechecks
-        ((e as any).path &&
-          (e as any).path.indexOf &&
-          (~(e as any).path.indexOf(self.input) ||
-            ~(e as any).path.indexOf(self.altInput)));
+        ((e as any).composedPath() &&
+          (e as any).composedPath().indexOf &&
+          (~(e as any).composedPath().indexOf(self.input) ||
+            ~(e as any).composedPath().indexOf(self.altInput)));
 
       const lostFocus =
         !isInput &&


### PR DESCRIPTION
Changed based on Chrome warning feedback since Event.path is deprecated as it can be checked at the image below.

More info about it here as well: https://chromestatus.com/feature/5726124632965120

![1666087212246](https://user-images.githubusercontent.com/5339917/196409688-a56ed326-706e-4ffc-b8dc-97e82cb58e2a.png)

Also fixes https://github.com/flatpickr/flatpickr/issues/2766

Cheers,
JR