### PR TITLE
jumpToDate now jumps to a date that meets minDate & maxDate requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flatpickr",
-  "version": "4.6.13",
+  "version": "4.6.15",
   "description": "A lightweight, powerful javascript datetime picker",
   "scripts": {
     "build": "run-s build:pre build:build build:esm build:types build:post",

--- a/src/index.ts
+++ b/src/index.ts
@@ -499,15 +499,26 @@ function FlatpickrInstance(
    * @param {boolean} triggerChange if change events should be triggered
    */
   function jumpToDate(jumpDate?: DateOption, triggerChange?: boolean) {
-    const jumpTo =
-      jumpDate !== undefined
-        ? self.parseDate(jumpDate)
-        : self.latestSelectedDateObj ||
-          (self.config.minDate && self.config.minDate > self.now
-            ? self.config.minDate
-            : self.config.maxDate && self.config.maxDate < self.now
-            ? self.config.maxDate
-            : self.now);
+    let jumpTo;
+
+    if (jumpDate !== undefined) {
+      jumpTo = self.parseDate(jumpDate);
+    } else if (
+      self.latestSelectedDateObj !== undefined &&
+      // latestSelectedDateObj meets the minDate & maxDate requirements (if set)
+      (!self.config.minDate ||
+        self.latestSelectedDateObj >= self.config.minDate) &&
+      (!self.config.maxDate ||
+        self.latestSelectedDateObj <= self.config.maxDate)
+    ) {
+      jumpTo = self.latestSelectedDateObj;
+    } else if (self.config.minDate && self.config.minDate > self.now) {
+      jumpTo = self.config.minDate;
+    } else if (self.config.maxDate && self.config.maxDate < self.now) {
+      jumpTo = self.config.maxDate;
+    } else {
+      jumpTo = self.now;
+    }
 
     const oldYear = self.currentYear;
     const oldMonth = self.currentMonth;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1491,7 +1491,7 @@ function FlatpickrInstance(
         if (self.config.allowInput) {
           self.setDate(
             self._input.value,
-            false,
+            true,
             self.config.altInput
               ? self.config.altFormat
               : self.config.dateFormat


### PR DESCRIPTION
We have two date inputs:
#dateInput1, who's minDate is equal to today
#dateInput2, who's minDate is equal to the date of #dateInput1 (or today, when #dateInput1 is empty)

We now set a date in both these inputs:
![image](https://user-images.githubusercontent.com/55881713/201862485-326adc64-fb25-41a0-815e-c987888784d1.png)

Then we set the date of #dateInput1 to a date with a month greater #dateInput2's month
![image](https://user-images.githubusercontent.com/55881713/201862566-5500883c-2183-49ab-9e85-1f07f169c45f.png)
This automatically clears #dateInput2 because it's value is lower than the minDate (correct behaviour)

But now, when we open #dateInput2, it opens November:
![image](https://user-images.githubusercontent.com/55881713/201863834-6bb914f2-7ad0-4017-9b53-de3cb572f3f2.png)
This is because the jumpTo behaviour works like this:
- Is a date given? Set it to that date
- Set it to **latestSelectedDateObj** (if not undefined)
- Set it to minDate (if not undefined and greater than today)
- set it to maxDate (if not undefined and lower than today)

The problem here is that latestSelectedDateObj of #dateInput2 was 2022-11-26 (November), which lies before the new minDate 2022-12-10 (December).

The jumpTo function does not check if latestSelectedDateObj meets the minDate & maxDate "requirements" and the user lands on a month with disabled dates.

The solution:
**Only jump to latestSelectedDateObj if it meets the minDate and maxDate requirements (if these are set ofcourse)**
