### PR TITLE
Fix typings when using NodeNext module resolution

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -37,4 +37,4 @@ declare namespace flatpickr {
   }
 }
 
-export default flatpickr;
+export = flatpickr;


### PR DESCRIPTION
This PR fixes the type declarations to work when `moduleResolution` is `NodeNext`. I believe this may be related to https://github.com/microsoft/TypeScript/issues/50690.

Here's a playground illustrating that the current typings work correctly with `ESNext` module resolution:

https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAMwDYEMZmAYwNZUVCEOAcmTQxymIG4AoWs9LXACgBMJMBXEAUwDsYAOgCOXXlACeAZV5JemGNBbE2wAG7EAlAEIt1IA

<img width="389" alt="Screenshot 2023-02-07 at 11 00 25" src="https://user-images.githubusercontent.com/1476544/217340535-8be555d8-ab8d-4bc2-907f-8483a8b6e528.png">

And here's the exact same code broken with `NodeNext` module resolution:

https://www.typescriptlang.org/play?target=99&moduleResolution=99&module=199#code/JYWwDg9gTgLgBAMwDYEMZmAYwNZUVCEOAcmTQxymIG4AoWs9LXACgBMJMBXEAUwDsYAOgCOXXlACeAZV5JemGNBbE2wAG7EAlAEIt1IA

<img width="798" alt="Screenshot 2023-02-07 at 11 00 38" src="https://user-images.githubusercontent.com/1476544/217340534-6a70e9d5-6d34-4009-bb6d-2c4f65b44a21.png">