### PR TITLE
Create fa_-lm

### DIFF
--- a/src/l10n/fa_-lm
+++ b/src/l10n/fa_-lm
@@ -1,0 +1,64 @@
+/* Farsi (Persian) locals for flatpickr */
+import { CustomLocale } from "../types/locale";
+import { FlatpickrFn } from "../types/instance";
+
+const fp =
+  typeof window !== "undefined" && window.flatpickr !== undefined
+    ? window.flatpickr
+    : ({
+        l10ns: {},
+      } as FlatpickrFn);
+
+export const Persian: CustomLocale = {
+  weekdays: {
+    shorthand: ["یک", "دو", "سه", "چهار", "پنج", "جمعه", "شنبه"],
+    longhand: [
+      "یک‌شنبه",
+      "دوشنبه",
+      "سه‌شنبه",
+      "چهارشنبه",
+      "پنچ‌شنبه",
+      "جمعه",
+      "شنبه",
+    ],
+  },
+
+  months: {
+    shorthand: [
+      "فرو",
+      "ارد",
+      "خرد",
+      "تیر",
+      "مرد",
+      "شهر",
+      "مهر",
+      "آبا",
+      "آذر",
+      "دی",
+      "بهم",
+      "اسف",
+    ],
+    longhand: [
+      "فروردین",
+      "اردیبهشت",
+      "خرداد",
+      "تیر",
+      "مرداد",
+      "شهریور",
+      "مهر",
+      "آبان",
+      "آذر",
+      "دی",
+      "بهمن",
+      "اسفند",
+    ],
+  },
+  firstDayOfWeek: 6,
+  ordinal: () => {
+    return "";
+  },
+};
+
+fp.l10ns.fa = Persian;
+
+export default fp.l10ns;


### PR DESCRIPTION
Add fa localization with Persian month names

The fa.ts file only translates the months and does not contain the real names of the months in Persian language