### PR TITLE
Fix an issue at MonthSelect plugin related with aria-labels values

### DIFF
--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -134,6 +134,16 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
             );
         }
       );
+
+      const yearInputParent = fp.yearElements[0].parentElement as HTMLElement,
+            yearNavArrowUp = yearInputParent.querySelector(".arrowUp") as HTMLElement,
+            yearNavArrowDown = yearInputParent.querySelector(".arrowDown") as HTMLElement;
+
+      fp._bind([yearNavArrowUp, yearNavArrowDown], "click", function () {
+          setTimeout(() => {
+              buildMonths();
+          }, 0);
+      }); 
     }
 
     function setCurrentlySelected() {

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -136,14 +136,18 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
       );
 
       const yearInputParent = fp.yearElements[0].parentElement as HTMLElement,
-            yearNavArrowUp = yearInputParent.querySelector(".arrowUp") as HTMLElement,
-            yearNavArrowDown = yearInputParent.querySelector(".arrowDown") as HTMLElement;
+        yearNavArrowUp = yearInputParent.querySelector(
+          ".arrowUp"
+        ) as HTMLElement,
+        yearNavArrowDown = yearInputParent.querySelector(
+          ".arrowDown"
+        ) as HTMLElement;
 
       fp._bind([yearNavArrowUp, yearNavArrowDown], "click", function () {
-          setTimeout(() => {
-              buildMonths();
-          }, 0);
-      }); 
+        setTimeout(() => {
+          buildMonths();
+        }, 0);
+      });
     }
 
     function setCurrentlySelected() {


### PR DESCRIPTION
This PR will solve an issue related with aria-label values at the months items, when changed year through year up and down arrows those values was not being proper updated.

Before:
![Untitled](https://user-images.githubusercontent.com/5339917/218778431-9439096c-9e9f-4c1e-a384-a8e3d5e4482f.gif)

After:
![Untitled2](https://user-images.githubusercontent.com/5339917/218779687-208ef3fd-dce7-4e4d-b811-f595f12a68a8.gif)

