### PR TITLE
ROU-4308: Fix issue on blur event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1331,7 +1331,9 @@ function FlatpickrInstance(
   }
 
   function clear(triggerChangeEvent = true, toInitial = true) {
-    self.input.value = "";
+    if (self.config.updateInputVal) {
+      self.input.value = "";
+    }
 
     if (self.altInput !== undefined) self.altInput.value = "";
 
@@ -2006,6 +2008,7 @@ function FlatpickrInstance(
       "static",
       "enableSeconds",
       "disableMobile",
+      "updateInputVal",
     ];
 
     const userConfig = {
@@ -2841,7 +2844,9 @@ function FlatpickrInstance(
           : "";
     }
 
-    self.input.value = getDateStr(self.config.dateFormat);
+    if (self.config.updateInputVal) {
+      self.input.value = getDateStr(self.config.dateFormat);
+    }
 
     if (self.altInput !== undefined) {
       self.altInput.value = getDateStr(self.config.altFormat);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1624,9 +1624,12 @@ function FlatpickrInstance(
 
   function onBlur(e: FocusEvent) {
     const isInput = e.target === self._input;
-    const clonedInput = self.input.closest('.flatpickr-input') as HTMLElement;
-    const clonedInputValue = clonedInput.getAttribute('value') as string;
-    const valueChanged = self._input.value.trimEnd() !== self.formatDate(new Date(clonedInputValue), self.config.altFormat);
+    let valueChanged = true;
+    
+    if (self.config.altInput) {
+      const hiddenInputValue = self.element.getAttribute('value') as string;
+      valueChanged = self._input.value.trimEnd() !== self.formatDate(new Date(hiddenInputValue), self.config.altFormat);
+    }
 
     if (
       isInput &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1462,10 +1462,10 @@ function FlatpickrInstance(
         self.element.contains(eventTarget as HTMLElement) ||
         // web components
         // e.path is not present in all browsers. circumventing typechecks
-        ((e as any).path &&
-          (e as any).path.indexOf &&
-          (~(e as any).path.indexOf(self.input) ||
-            ~(e as any).path.indexOf(self.altInput)));
+        ((e as any).composedPath() &&
+          (e as any).composedPath().indexOf &&
+          (~(e as any).composedPath().indexOf(self.input) ||
+            ~(e as any).composedPath().indexOf(self.altInput)));
 
       const lostFocus =
         !isInput &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1624,7 +1624,9 @@ function FlatpickrInstance(
 
   function onBlur(e: FocusEvent) {
     const isInput = e.target === self._input;
-    const valueChanged = self._input.value.trimEnd() !== getDateStr();
+    const clonedInput = self.input.closest('.flatpickr-input') as HTMLElement;
+    const clonedInputValue = clonedInput.getAttribute('value') as string;
+    const valueChanged = self._input.value.trimEnd() !== self.formatDate(new Date(clonedInputValue), self.config.altFormat);
 
     if (
       isInput &&

--- a/src/l10n/index.ts
+++ b/src/l10n/index.ts
@@ -125,6 +125,7 @@ const l10n: Record<key, CustomLocale> = {
   th,
   tr,
   uk,
+  vi: vn,
   vn,
   zh,
   zh_tw: zhTw,

--- a/src/l10n/vn.ts
+++ b/src/l10n/vn.ts
@@ -58,6 +58,6 @@ export const Vietnamese: CustomLocale = {
   rangeSeparator: " đến ",
 };
 
-fp.l10ns.vn = Vietnamese;
+fp.l10ns.vn = fp.l10ns.vi = Vietnamese;
 
 export default fp.l10ns;

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -134,6 +134,16 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
             );
         }
       );
+
+      const yearInputParent = fp.yearElements[0].parentElement as HTMLElement,
+            yearNavArrowUp = yearInputParent.querySelector(".arrowUp") as HTMLElement,
+            yearNavArrowDown = yearInputParent.querySelector(".arrowDown") as HTMLElement;
+
+      fp._bind([yearNavArrowUp, yearNavArrowDown], "click", function () {
+          setTimeout(() => {
+              buildMonths();
+          }, 0);
+      }); 
     }
 
     function setCurrentlySelected() {

--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -136,14 +136,18 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
       );
 
       const yearInputParent = fp.yearElements[0].parentElement as HTMLElement,
-            yearNavArrowUp = yearInputParent.querySelector(".arrowUp") as HTMLElement,
-            yearNavArrowDown = yearInputParent.querySelector(".arrowDown") as HTMLElement;
+        yearNavArrowUp = yearInputParent.querySelector(
+          ".arrowUp"
+        ) as HTMLElement,
+        yearNavArrowDown = yearInputParent.querySelector(
+          ".arrowDown"
+        ) as HTMLElement;
 
       fp._bind([yearNavArrowUp, yearNavArrowDown], "click", function () {
-          setTimeout(() => {
-              buildMonths();
-          }, 0);
-      }); 
+        setTimeout(() => {
+          buildMonths();
+        }, 0);
+      });
     }
 
     function setCurrentlySelected() {

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -172,6 +172,7 @@ export type key =
   | "th"
   | "tr"
   | "uk"
+  | "vi"
   | "vn"
   | "zh"
   | "uz"

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -261,6 +261,12 @@ Use it along with "enableTime" to create a time picker. */
   /* Displays time picker in 24 hour mode without AM/PM selection when enabled.*/
   time_24hr: boolean;
 
+  /* Update input value attribute when a date has been selected,
+  - Used in conjunction with altInput config since this will prevent the update value of the hidden input.
+  - With this approach issues related with different assigned values to this input will be fixed since it must be 
+  Controlled by developer at the OnSelectedDate callback */
+  updateInputVal: boolean;
+
   /* Display week numbers left of the calendar. */
   weekNumbers: boolean;
 
@@ -337,6 +343,7 @@ export interface ParsedOptions {
   showMonths: number;
   static: boolean;
   time_24hr: boolean;
+  updateInputVal: boolean;
   weekNumbers: boolean;
   wrap: boolean;
 }
@@ -419,6 +426,7 @@ export const defaults: ParsedOptions = {
   showMonths: 1,
   static: false,
   time_24hr: false,
+  updateInputVal: true,
   weekNumbers: false,
   wrap: false,
 };


### PR DESCRIPTION
This isue was introduced with the v4.6.13 and the flatpickr loses the support of update the value when the blur event is triggered. This issue was introcuded on the commit https://github.com/flatpickr/flatpickr/issues/2668, with the validation of the input value and comparing dates.

The previous approach block the update of the values when a past date occur or typing, without press enter. The library just need to close the ballon to update the values. Now with the fix, we prevent the twice triggering of the event and update the value on close the ballon.