### PR TITLE
Add fractional seconds support for direct input

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1282,6 +1282,37 @@ describe("flatpickr", () => {
       expect(fp.hourElement.value).toEqual("09");
     });
 
+    it("time input seconds must be cleared after hours increment when not enabled", () => {
+      createInstance({
+        dateFormat: "Y-m-d H:i:S",
+        enableTime: true,
+        defaultDate: "2000-12-13 5:6:3",
+      });
+
+      expect(fp.input.value).toEqual("2000-12-13 05:06:03");
+
+      fp.open();
+
+      incrementTime("hourElement", 1);
+      expect(fp.input.value).toEqual("2000-12-13 06:06:00");
+    });
+
+    it("time input seconds must be kept after hours increment when enabled", () => {
+      createInstance({
+        dateFormat: "Y-m-d H:i:S",
+        enableTime: true,
+        enableSeconds: true,
+        defaultDate: "2000-12-13 5:6:3",
+      });
+
+      expect(fp.input.value).toEqual("2000-12-13 05:06:03");
+
+      fp.open();
+
+      incrementTime("hourElement", 1);
+      expect(fp.input.value).toEqual("2000-12-13 06:06:03");
+    });
+
     it("time input respects minDate", () => {
       createInstance({
         enableTime: true,

--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -528,7 +528,7 @@ describe("flatpickr", () => {
           parseDate(dateStr, formatStr) {
             let segs = formatStr.split("-");
             let date = new Date();
-            dateStr.split(".*^*.").forEach((v, i) => {
+            (dateStr as string).split(".*^*.").forEach((v, i) => {
               if (i === 0) return;
               let seg = segs[i - 1];
               switch (seg) {
@@ -575,6 +575,30 @@ describe("flatpickr", () => {
 
         fp.setDate(new Date(2016, 10, 20));
         expect(fp.input.value).not.toEqual(RESULT);
+      });
+
+      it("flatpickr.formatDate() must accept fractional seconds precision", () => {
+        createInstance({
+          allowInput: true,
+          dateFormat: "Y-m-d H:i:S",
+          formatDate(date, formatStr, locale) {
+            return flatpickr
+              .formatDate(date, formatStr, locale, 5)
+              .replace(/:0{1,2}(\.0+)?$/, "");
+          },
+        });
+
+        fp.input.focus();
+        fp.input.value = "2020-10-20 15:16:17.8009";
+        fp.input.blur();
+
+        expect(fp.input.value).toEqual("2020-10-20 15:16:17.80090");
+
+        fp.input.focus();
+        fp.input.value = "2020-10-20 15:16:00";
+        fp.input.blur();
+
+        expect(fp.input.value).toEqual("2020-10-20 15:16");
       });
     });
   });

--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1107,6 +1107,67 @@ describe("flatpickr", () => {
       expect(fp.selectedDates[0].getMinutes()).toEqual(17);
     });
 
+    it("direct entry when allowInput is true must preserve milliseconds/nanoseconds", () => {
+      createInstance({
+        dateFormat: "j.n.Y h:i:s.N K",
+        allowInput: true,
+        enableTime: true,
+        defaultDate: "2.7.2040 5:6:3.8 PM",
+      });
+      expect(fp.selectedDates[0]).toBeDefined();
+      expect(fp.selectedDates[0].getFullYear()).toEqual(2040);
+      expect(fp.selectedDates[0].getMonth()).toEqual(6); // 6 === July
+      expect(fp.selectedDates[0].getDate()).toEqual(2);
+      expect(fp.selectedDates[0].getHours()).toEqual(17);
+      expect(fp.selectedDates[0].getMinutes()).toEqual(6);
+      expect(fp.selectedDates[0].getSeconds()).toEqual(3);
+      expect(fp.selectedDates[0].getMilliseconds()).toEqual(800);
+
+      // set - no change
+      fp.input.focus();
+      fp.input.value = "2.7.2040 5:6:3.8 PM";
+      fp.input.blur();
+
+      expect(fp.selectedDates[0]).toBeDefined();
+      expect(fp.selectedDates[0].getFullYear()).toEqual(2040);
+      expect(fp.selectedDates[0].getMonth()).toEqual(6); // 6 === July
+      expect(fp.selectedDates[0].getDate()).toEqual(2);
+      expect(fp.selectedDates[0].getHours()).toEqual(17);
+      expect(fp.selectedDates[0].getMinutes()).toEqual(6);
+      expect(fp.selectedDates[0].getSeconds()).toEqual(3);
+      expect(fp.selectedDates[0].getMilliseconds()).toEqual(800);
+
+      // set2 - update
+      fp.input.focus();
+      fp.input.value = "4.9.2060 1:2:3.9770655 AM";
+      fp.input.blur();
+
+      expect(fp.selectedDates[0]).toBeDefined();
+      expect(fp.selectedDates[0].getFullYear()).toEqual(2060);
+      expect(fp.selectedDates[0].getMonth()).toEqual(8); // 8 === September
+      expect(fp.selectedDates[0].getDate()).toEqual(4);
+      expect(fp.selectedDates[0].getHours()).toEqual(1);
+      expect(fp.selectedDates[0].getMinutes()).toEqual(2);
+      expect(fp.selectedDates[0].getSeconds()).toEqual(3);
+      expect(fp.selectedDates[0].getMilliseconds()).toEqual(977);
+      expect((fp.selectedDates[0] as any).flatpickrNanoseconds).toEqual(65_500);
+
+      // set2 - no change
+      fp.input.focus();
+      fp.input.value = "4.9.2060 1:2:3.9770655 AM";
+      fp.input.blur();
+
+      expect(fp.selectedDates[0]).toBeDefined();
+      expect(fp.selectedDates[0].getFullYear()).toEqual(2060);
+      expect(fp.selectedDates[0].getMonth()).toEqual(8); // 8 === September
+      expect(fp.selectedDates[0].getDate()).toEqual(4);
+      expect(fp.selectedDates[0].getHours()).toEqual(1);
+      expect(fp.selectedDates[0].getMinutes()).toEqual(2);
+      expect(fp.selectedDates[0].getSeconds()).toEqual(3);
+      expect(fp.selectedDates[0].getMilliseconds()).toEqual(977);
+      expect((fp.selectedDates[0] as any).flatpickrNanoseconds).toEqual(65_500);
+    });
+
     it("Renders week numbers correctly", () => {
       createInstance({
         weekNumbers: true,

--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -176,6 +176,9 @@ describe("flatpickr", () => {
         expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
         expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
         expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(
+          date.getMilliseconds()
+        );
       });
 
       it("should parse unix time", () => {
@@ -189,6 +192,9 @@ describe("flatpickr", () => {
         expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
         expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
         expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(
+          date.getMilliseconds()
+        );
       });
 
       it('should parse "2016-10"', () => {
@@ -412,12 +418,12 @@ describe("flatpickr", () => {
         DEFAULT_FORMAT_3 = "Y-m-d";
 
       it(`should format the date with the pattern "${DEFAULT_FORMAT_1}"`, () => {
-        const RESULT = "20.10.16 09:19:59";
+        const RESULT = "20.10.16 09:19:09";
         createInstance({
           dateFormat: DEFAULT_FORMAT_1,
         });
 
-        fp.setDate("20.10.16 09:19:59");
+        fp.setDate("20.10.16 09:19:09");
         expect(fp.input.value).toEqual(RESULT);
         fp.setDate("2015.11.21 19:29:49");
         expect(fp.input.value).not.toEqual(RESULT);
@@ -640,7 +646,7 @@ describe("flatpickr", () => {
       }
 
       fp.setDate("");
-      expect(fp.latestSelectedDateObj).toEqual(undefined);
+      expect(fp.latestSelectedDateObj).toBeUndefined();
     });
 
     it("parses dates in enable[] and disable[]", () => {

--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -171,6 +171,7 @@ describe("flatpickr", () => {
           defaultDate: 1477111633771,
           enableTime: true,
           enableSeconds: true,
+          formatSecondsPrecision: 9,
         });
 
         const date = new Date("2016-10-22T04:47:13.771Z");
@@ -178,16 +179,57 @@ describe("flatpickr", () => {
         expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
         expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
         expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
-        // TODO - needs fractional seconds support
-        // expect(fp.selectedDates[0].getMilliseconds()).toEqual(
-        //   date.getMilliseconds()
-        // );
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(
+          date.getMilliseconds()
+        );
+        expect(
+          (fp.selectedDates[0] as any).flatpickrNanoseconds
+        ).toBeUndefined();
       });
 
-      it("should parse unix time", () => {
+      it("should parse unix time - without fractional seconds", () => {
         createInstance({
-          defaultDate: "1477111633.7710234564", // shouldn't parse as a timestamp
-          dateFormat: "U.N",
+          defaultDate: "1477111633", // shouldn't parse as a timestamp
+          dateFormat: "U",
+          formatSecondsPrecision: 9,
+        });
+
+        const date = new Date("2016-10-22T04:47:13Z");
+        expect(fp.selectedDates[0]).toBeDefined();
+        expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
+        expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
+        expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(0);
+        expect(
+          (fp.selectedDates[0] as any).flatpickrNanoseconds
+        ).toBeUndefined();
+      });
+
+      it("should parse unix time - with milliseconds", () => {
+        createInstance({
+          defaultDate: "1477111633.771",
+          dateFormat: "U",
+          formatSecondsPrecision: 9,
+        });
+
+        const date = new Date("2016-10-22T04:47:13.771Z");
+        expect(fp.selectedDates[0]).toBeDefined();
+        expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
+        expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
+        expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(
+          date.getMilliseconds()
+        );
+        expect(
+          (fp.selectedDates[0] as any).flatpickrNanoseconds
+        ).toBeUndefined();
+      });
+
+      it("should parse unix time - with nanoseconds", () => {
+        createInstance({
+          defaultDate: "1477111633.7710234564",
+          dateFormat: "U",
+          formatSecondsPrecision: 9,
         });
 
         const date = new Date("2016-10-22T04:47:13.771Z");
@@ -199,28 +241,15 @@ describe("flatpickr", () => {
           date.getMilliseconds()
         );
         expect((fp.selectedDates[0] as any).flatpickrNanoseconds).toEqual(
-          23456
+          23_456
         );
       });
 
-      it("should parse U with floating point", () => {
+      it("should parse u with decimal point", () => {
         createInstance({
-          defaultDate: "1477111633.771",
-          dateFormat: "U",
-        });
-
-        const date = new Date("2016-10-22T04:47:13Z");
-        expect(fp.selectedDates[0]).toBeDefined();
-        expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
-        expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
-        expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
-        expect(fp.selectedDates[0].getMilliseconds()).toEqual(0);
-      });
-
-      it("should parse u with floating point", () => {
-        createInstance({
-          defaultDate: "1477111633771.4",
+          defaultDate: "1477111633771.23457",
           dateFormat: "u",
+          formatSecondsPrecision: 9,
         });
 
         const date = new Date("2016-10-22T04:47:13.771Z");
@@ -231,20 +260,9 @@ describe("flatpickr", () => {
         expect(fp.selectedDates[0].getMilliseconds()).toEqual(
           date.getMilliseconds()
         );
-      });
-
-      it("should parse U.N without explicit fractional seconds", () => {
-        createInstance({
-          defaultDate: "1477111633",
-          dateFormat: "U.N",
-        });
-
-        const date = new Date("2016-10-22T04:47:13Z");
-        expect(fp.selectedDates[0]).toBeDefined();
-        expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
-        expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
-        expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
-        expect(fp.selectedDates[0].getMilliseconds()).toEqual(0);
+        expect((fp.selectedDates[0] as any).flatpickrNanoseconds).toEqual(
+          234_570
+        );
       });
 
       it('should parse "2016-10"', () => {
@@ -1156,7 +1174,7 @@ describe("flatpickr", () => {
 
     it("direct entry when allowInput is true must preserve milliseconds/nanoseconds", () => {
       createInstance({
-        dateFormat: "j.n.Y h:i:s.N K",
+        dateFormat: "j.n.Y h:i:s K",
         allowInput: true,
         enableTime: true,
         defaultDate: "2.7.2040 5:6:3.8 PM",
@@ -1169,6 +1187,7 @@ describe("flatpickr", () => {
       expect(fp.selectedDates[0].getMinutes()).toEqual(6);
       expect(fp.selectedDates[0].getSeconds()).toEqual(3);
       expect(fp.selectedDates[0].getMilliseconds()).toEqual(800);
+      expect((fp.selectedDates[0] as any).flatpickrNanoseconds).toBeUndefined();
 
       // set - no change
       fp.input.focus();
@@ -1183,6 +1202,7 @@ describe("flatpickr", () => {
       expect(fp.selectedDates[0].getMinutes()).toEqual(6);
       expect(fp.selectedDates[0].getSeconds()).toEqual(3);
       expect(fp.selectedDates[0].getMilliseconds()).toEqual(800);
+      expect((fp.selectedDates[0] as any).flatpickrNanoseconds).toBeUndefined();
 
       // set2 - update
       fp.input.focus();
@@ -1417,10 +1437,11 @@ describe("flatpickr", () => {
       createInstance({
         dateFormat: "Y-m-d H:i:S",
         enableTime: true,
-        defaultDate: "2000-12-13 5:6:3",
+        defaultDate: "2000-12-13 5:6:3.010020",
+        formatSecondsPrecision: -1,
       });
 
-      expect(fp.input.value).toEqual("2000-12-13 05:06:03");
+      expect(fp.input.value).toEqual("2000-12-13 05:06:03.01002");
 
       fp.open();
 
@@ -1428,15 +1449,16 @@ describe("flatpickr", () => {
       expect(fp.input.value).toEqual("2000-12-13 06:06:00");
     });
 
-    it("time input seconds must be kept after hours increment when enabled", () => {
+    it("time input fractional seconds must be cleared after hours increment", () => {
       createInstance({
         dateFormat: "Y-m-d H:i:S",
         enableTime: true,
         enableSeconds: true,
-        defaultDate: "2000-12-13 5:6:3",
+        defaultDate: "2000-12-13 5:6:3.010020",
+        formatSecondsPrecision: -1,
       });
 
-      expect(fp.input.value).toEqual("2000-12-13 05:06:03");
+      expect(fp.input.value).toEqual("2000-12-13 05:06:03.01002");
 
       fp.open();
 

--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -186,8 +186,8 @@ describe("flatpickr", () => {
 
       it("should parse unix time", () => {
         createInstance({
-          defaultDate: "1477111633.771", // shouldnt parse as a timestamp
-          dateFormat: "U",
+          defaultDate: "1477111633.7710234564", // shouldn't parse as a timestamp
+          dateFormat: "U.N",
         });
 
         const date = new Date("2016-10-22T04:47:13.771Z");
@@ -198,6 +198,53 @@ describe("flatpickr", () => {
         expect(fp.selectedDates[0].getMilliseconds()).toEqual(
           date.getMilliseconds()
         );
+        expect((fp.selectedDates[0] as any).flatpickrNanoseconds).toEqual(
+          23456
+        );
+      });
+
+      it("should parse U with floating point", () => {
+        createInstance({
+          defaultDate: "1477111633.771",
+          dateFormat: "U",
+        });
+
+        const date = new Date("2016-10-22T04:47:13Z");
+        expect(fp.selectedDates[0]).toBeDefined();
+        expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
+        expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
+        expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(0);
+      });
+
+      it("should parse u with floating point", () => {
+        createInstance({
+          defaultDate: "1477111633771.4",
+          dateFormat: "u",
+        });
+
+        const date = new Date("2016-10-22T04:47:13.771Z");
+        expect(fp.selectedDates[0]).toBeDefined();
+        expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
+        expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
+        expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(
+          date.getMilliseconds()
+        );
+      });
+
+      it("should parse U.N without explicit fractional seconds", () => {
+        createInstance({
+          defaultDate: "1477111633",
+          dateFormat: "U.N",
+        });
+
+        const date = new Date("2016-10-22T04:47:13Z");
+        expect(fp.selectedDates[0]).toBeDefined();
+        expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
+        expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
+        expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
+        expect(fp.selectedDates[0].getMilliseconds()).toEqual(0);
       });
 
       it('should parse "2016-10"', () => {

--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -169,6 +169,8 @@ describe("flatpickr", () => {
       it("should parse timestamp", () => {
         createInstance({
           defaultDate: 1477111633771,
+          enableTime: true,
+          enableSeconds: true,
         });
 
         const date = new Date("2016-10-22T04:47:13.771Z");
@@ -176,9 +178,10 @@ describe("flatpickr", () => {
         expect(fp.selectedDates[0].getFullYear()).toEqual(date.getFullYear());
         expect(fp.selectedDates[0].getMonth()).toEqual(date.getMonth());
         expect(fp.selectedDates[0].getDate()).toEqual(date.getDate());
-        expect(fp.selectedDates[0].getMilliseconds()).toEqual(
-          date.getMilliseconds()
-        );
+        // TODO - needs fractional seconds support
+        // expect(fp.selectedDates[0].getMilliseconds()).toEqual(
+        //   date.getMilliseconds()
+        // );
       });
 
       it("should parse unix time", () => {
@@ -457,6 +460,26 @@ describe("flatpickr", () => {
         const RESULT = "MAAAGIC.*^*.2016.*^*.20.*^*.10";
         createInstance({
           dateFormat: "YEAR-DAYOFMONTH-MONTH",
+          parseDate(dateStr, formatStr) {
+            let segs = formatStr.split("-");
+            let date = new Date();
+            dateStr.split(".*^*.").forEach((v, i) => {
+              if (i === 0) return;
+              let seg = segs[i - 1];
+              switch (seg) {
+                case "DAYOFMONTH":
+                  date.setDate(parseInt(v, 10));
+                  break;
+                case "MONTH":
+                  date.setMonth(parseInt(v, 10) - 1);
+                  break;
+                case "YEAR":
+                  date.setFullYear(parseInt(v, 10));
+                  break;
+              }
+            });
+            return date;
+          },
           formatDate(date, formatStr) {
             let segs = formatStr.split("-");
             return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,10 +179,11 @@ function FlatpickrInstance(
     e?: MouseEvent | IncrementEvent | KeyboardEvent | FocusEvent
   ) {
     if (self.selectedDates.length === 0) {
+      const now = new Date();
       const defaultDate =
         self.config.minDate === undefined ||
-        compareDates(new Date(), self.config.minDate) >= 0
-          ? new Date()
+        compareDates(now, self.config.minDate) >= 0
+          ? now
           : new Date(self.config.minDate.getTime());
 
       const defaults = getDefaultHours(self.config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,6 +355,11 @@ function FlatpickrInstance(
           self.latestSelectedDateObj.setSeconds(0);
         }
         self.latestSelectedDateObj.setMilliseconds(0);
+        if (
+          (self.latestSelectedDateObj as any).flatpickrNanoseconds !== undefined
+        ) {
+          delete (self.latestSelectedDateObj as any).flatpickrNanoseconds;
+        }
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,14 +185,10 @@ function FlatpickrInstance(
         compareDates(now, self.config.minDate) >= 0
           ? now
           : new Date(self.config.minDate.getTime());
+      defaultDate.setMilliseconds(0);
 
       const defaults = getDefaultHours(self.config);
-      defaultDate.setHours(
-        defaults.hours,
-        defaults.minutes,
-        defaults.seconds,
-        defaultDate.getMilliseconds()
-      );
+      defaultDate.setHours(defaults.hours, defaults.minutes, defaults.seconds);
 
       self.selectedDates = [defaultDate];
       self.latestSelectedDateObj = defaultDate;
@@ -316,7 +312,7 @@ function FlatpickrInstance(
       }
     }
 
-    setHours(hours, minutes, seconds);
+    setHours(hours, minutes, self.secondElement !== undefined ? seconds : null);
   }
 
   /**
@@ -337,11 +333,29 @@ function FlatpickrInstance(
    * @param {Number} hours the hour. whether its military
    *                 or am-pm gets inferred from config
    * @param {Number} minutes the minutes
-   * @param {Number} seconds the seconds (optional)
+   * @param {Number} seconds the seconds
    */
-  function setHours(hours: number, minutes: number, seconds: number) {
+  function setHours(hours: number, minutes: number, seconds: number | null) {
     if (self.latestSelectedDateObj !== undefined) {
-      self.latestSelectedDateObj.setHours(hours % 24, minutes, seconds || 0, 0);
+      const origHours = self.latestSelectedDateObj.getHours();
+      const origMinutes = self.latestSelectedDateObj.getMinutes();
+      const origSeconds = self.latestSelectedDateObj.getSeconds();
+      self.latestSelectedDateObj.setHours(
+        hours % 24,
+        minutes,
+        seconds !== null ? seconds : self.latestSelectedDateObj.getSeconds(),
+        self.latestSelectedDateObj.getMilliseconds()
+      );
+      if (
+        origHours !== self.latestSelectedDateObj.getHours() ||
+        origMinutes !== self.latestSelectedDateObj.getMinutes() ||
+        origSeconds !== self.latestSelectedDateObj.getSeconds()
+      ) {
+        if (seconds === null) {
+          self.latestSelectedDateObj.setSeconds(0);
+        }
+        self.latestSelectedDateObj.setMilliseconds(0);
+      }
     }
 
     if (!self.hourElement || !self.minuteElement || self.isMobile) return;
@@ -357,7 +371,7 @@ function FlatpickrInstance(
     if (self.amPM !== undefined)
       self.amPM.textContent = self.l10n.amPM[int(hours >= 12)];
 
-    if (self.secondElement !== undefined)
+    if (self.secondElement !== undefined && seconds !== null)
       self.secondElement.value = pad(seconds);
   }
 

--- a/src/plugins/rangePlugin.ts
+++ b/src/plugins/rangePlugin.ts
@@ -13,7 +13,7 @@ declare global {
 
 function rangePlugin(config: Config = {}): Plugin {
   return function (fp) {
-    let dateFormat = "",
+    let dateFormat: string,
       secondInput: HTMLInputElement,
       _secondInputFocused: boolean,
       _prevDates: Date[];

--- a/src/types/instance.ts
+++ b/src/types/instance.ts
@@ -1,4 +1,4 @@
-import { DateOption, Options, ParsedOptions } from "./options";
+import { DateOption, BaseOptions, Options, ParsedOptions } from "./options";
 import { Locale, CustomLocale, key as LocaleKey } from "./locale";
 
 import { RevFormat, Formats, TokenRegex } from "../utils/formatting";
@@ -160,12 +160,8 @@ export interface FlatpickrFn {
   l10ns: { [k in LocaleKey]?: CustomLocale } & { default: Locale };
   localize: (l10n: CustomLocale) => void;
   setDefaults: (config: Options) => void;
-  parseDate: (
-    date: DateOption,
-    format?: string,
-    timeless?: boolean
-  ) => Date | undefined;
-  formatDate: (date: Date, format: string) => string;
+  parseDate: BaseOptions["parseDate"];
+  formatDate: BaseOptions["formatDate"];
   compareDates: (date1: Date, date2: Date, timeless?: boolean) => number;
 }
 

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -380,7 +380,7 @@ export const defaults: ParsedOptions = {
     return (
       1 +
       Math.round(
-        ((date.getTime() - week1.getTime()) / 86400000 -
+        ((date.getTime() - week1.getTime()) / 86_400_000 -
           3 +
           ((week1.getDay() + 6) % 7)) /
           7

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -135,6 +135,10 @@ By default, Flatpickr utilizes native datetime widgets unless certain options (e
   /* Allows using a custom date formatting function instead of the built-in. Generally unnecessary.  */
   formatDate: (date: Date, format: string, locale: Locale) => string;
 
+  /* Fractional seconds precision (used only when seconds are present in the format).
+   */
+  formatSecondsPrecision: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
   /* If "weekNumbers" are enabled, this is the function that outputs the week number for a given dates, optionally along with other text  */
   getWeek: (date: Date) => string | number;
 
@@ -301,6 +305,7 @@ export interface ParsedOptions {
   enableTime: boolean;
   errorHandler: (err: Error) => void;
   formatDate?: Options["formatDate"];
+  formatSecondsPrecision: BaseOptions["formatSecondsPrecision"];
   getWeek: (date: Date) => string | number;
   hourIncrement: number;
   ignoredFocusElements: HTMLElement[];
@@ -366,6 +371,7 @@ export const defaults: ParsedOptions = {
   enableTime: false,
   errorHandler: (err: Error) =>
     typeof console !== "undefined" && console.warn(err),
+  formatSecondsPrecision: 0,
   getWeek: (givenDate: Date) => {
     const date = new Date(givenDate.getTime());
     date.setHours(0, 0, 0, 0);

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -133,7 +133,12 @@ By default, Flatpickr utilizes native datetime widgets unless certain options (e
   errorHandler: (e: Error) => void;
 
   /* Allows using a custom date formatting function instead of the built-in. Generally unnecessary.  */
-  formatDate: (date: Date, format: string, locale: Locale) => string;
+  formatDate: (
+    date: Date,
+    format: string,
+    locale: Locale,
+    formatSecondsPrecision: BaseOptions["formatSecondsPrecision"]
+  ) => string;
 
   /* Fractional seconds precision (used only when seconds are present in the format).
    */
@@ -223,7 +228,12 @@ Use it along with "enableTime" to create a time picker. */
   onPreCalendarPosition: Hook | Hook[];
 
   /* A custom datestring parser */
-  parseDate: (date: string, format: string) => Date;
+  parseDate: (
+    date: string | Date,
+    format: string,
+    timeless: boolean,
+    locale: Locale
+  ) => Date | undefined;
 
   /* Plugins. See https://chmln.github.io/flatpickr/plugins/ */
   plugins: Plugin[];

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -50,22 +50,30 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
 ): Date | undefined => {
   if (date !== 0 && !date) return undefined;
 
+  const format = givenFormat || (config || defaults).dateFormat;
   const locale = customLocale || l10n;
 
   let parsedDate: Date | undefined;
   const dateOrig = date;
 
-  if (date instanceof Date) parsedDate = new Date(date.getTime());
-  else if (
+  if (
     typeof date !== "string" &&
-    date.toFixed !== undefined // timestamp
-  )
-    // create a copy
+    !(date instanceof Date) &&
+    (date as any).toFixed !== undefined // timestamp in milliseconds
+  ) {
+    date = new Date(date);
+  }
 
-    parsedDate = new Date(date);
-  else if (typeof date === "string") {
+  if (date instanceof Date) {
+    date = createDateFormatter({ config: config, l10n: l10n })(
+      date,
+      format,
+      locale
+    );
+  }
+
+  if (typeof date === "string") {
     // date string
-    const format = givenFormat || (config || defaults).dateFormat;
     const datestr = String(date).trim();
 
     if (datestr === "today") {

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -79,7 +79,7 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
     ) {
       parsedDate = new Date(date);
     } else {
-      let matched,
+      let matched = false,
         ops: { fn: RevFormatFn; val: string }[] = [];
 
       for (let i = 0, matchIndex = 0, regexStr = ""; i < format.length; i++) {
@@ -90,7 +90,8 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
         if (tokenRegex[token] && !escaped) {
           regexStr += tokenRegex[token];
           const match = new RegExp(regexStr).exec(date);
-          if (match && (matched = true)) {
+          if (match) {
+            matched = true;
             ops[token !== "Y" ? "push" : "unshift"]({
               fn: revFormat[token],
               val: match[++matchIndex],
@@ -119,9 +120,13 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
     return undefined;
   }
 
-  if (timeless === true) parsedDate.setHours(0, 0, 0, 0);
-
-  return parsedDate;
+  return timeless === true
+    ? new Date(
+        parsedDate.getFullYear(),
+        parsedDate.getMonth(),
+        parsedDate.getDate()
+      )
+    : parsedDate;
 };
 
 /**
@@ -169,7 +174,7 @@ export const parseSeconds = (secondsSinceMidnight: number) => {
 };
 
 export const duration = {
-  DAY: 86400000,
+  DAY: 86_400_000,
 };
 
 export function getDefaultHours(config: ParsedOptions) {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -141,9 +141,9 @@ export const tokenRegex: TokenRegex = {
   J: "(\\d{1,2})\\w+",
   K: "", // locale-dependent, setup on runtime
   M: "", // locale-dependent, setup on runtime
-  N: "((?<=.)\\d+(?!\\d))",
+  N: "((?<=\\.)\\d+(?!\\d))",
   S: "(\\d{1,2})",
-  U: "(\\d+(?:\\.\\d+)?)",
+  U: "(\\d+)",
   W: "(\\d{1,2})",
   Y: "(\\d{4})",
   Z: "(.+)",
@@ -155,7 +155,7 @@ export const tokenRegex: TokenRegex = {
   m: "(\\d{1,2})",
   n: "(\\d{1,2})",
   s: "(\\d{1,2})",
-  u: "(\\d+(?:\\.\\d+)?)",
+  u: "(\\d+)",
   w: "(\\d{1,2})",
   y: "(\\d{2})",
 };
@@ -219,7 +219,7 @@ export const formats: Formats = {
   S: (date: Date) => pad(date.getSeconds()),
 
   // unix timestamp
-  U: (date: Date) => date.getTime() / 1000,
+  U: (date: Date) => Math.floor(date.getTime() / 1000),
 
   W: function (date: Date, _: Locale, options: ParsedOptions) {
     return options.getWeek(date);

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -10,6 +10,7 @@ export type token =
   | "J"
   | "K"
   | "M"
+  | "N"
   | "S"
   | "U"
   | "W"
@@ -63,6 +64,18 @@ export const revFormat: RevFormat = {
   },
   M: function (dateObj: Date, shortMonth: string, locale: Locale) {
     dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
+  },
+  N: (dateObj: Date, fractionalSeconds: string) => {
+    var nanos = Math.floor(
+      parseFloat(fractionalSeconds) * Math.pow(10, 9 - fractionalSeconds.length)
+    );
+    dateObj.setMilliseconds(Math.floor(nanos / 1_000_000));
+    nanos = nanos - dateObj.getMilliseconds() * 1_000_000;
+    if (nanos) {
+      (dateObj as any).flatpickrNanoseconds = nanos;
+    } else if ((dateObj as any).flatpickrNanoseconds !== undefined) {
+      delete (dateObj as any).flatpickrNanoseconds;
+    }
   },
   S: (dateObj: Date, seconds: string) => {
     dateObj.setSeconds(parseFloat(seconds));
@@ -128,6 +141,7 @@ export const tokenRegex: TokenRegex = {
   J: "(\\d{1,2})\\w+",
   K: "", // locale-dependent, setup on runtime
   M: "", // locale-dependent, setup on runtime
+  N: "((?<=.)\\d+(?!\\d))",
   S: "(\\d{1,2})",
   U: "(\\d+(?:\\.\\d+)?)",
   W: "(\\d{1,2})",
@@ -192,6 +206,14 @@ export const formats: Formats = {
   M: function (date: Date, locale: Locale) {
     return monthToStr(date.getMonth(), true, locale);
   },
+
+  // fractional seconds with nanosecond precision (0-999_999_999)
+  N: (date: Date) =>
+    pad(
+      date.getMilliseconds() * 1_000_000 +
+        ((date as any).flatpickrNanoseconds || 0),
+      9
+    ),
 
   // seconds (00-59)
   S: (date: Date) => pad(date.getSeconds()),

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -123,26 +123,26 @@ export type TokenRegex = { [k in token]: string };
 export const tokenRegex: TokenRegex = {
   D: "", // locale-dependent, setup on runtime
   F: "", // locale-dependent, setup on runtime
-  G: "(\\d\\d|\\d)",
-  H: "(\\d\\d|\\d)",
-  J: "(\\d\\d|\\d)\\w+",
+  G: "(\\d{1,2})",
+  H: "(\\d{1,2})",
+  J: "(\\d{1,2})\\w+",
   K: "", // locale-dependent, setup on runtime
   M: "", // locale-dependent, setup on runtime
-  S: "(\\d\\d|\\d)",
-  U: "(.+)",
-  W: "(\\d\\d|\\d)",
+  S: "(\\d{1,2})",
+  U: "(\\d+(?:\\.\\d+)?)",
+  W: "(\\d{1,2})",
   Y: "(\\d{4})",
   Z: "(.+)",
-  d: "(\\d\\d|\\d)",
-  h: "(\\d\\d|\\d)",
-  i: "(\\d\\d|\\d)",
-  j: "(\\d\\d|\\d)",
+  d: "(\\d{1,2})",
+  h: "(\\d{1,2})",
+  i: "(\\d{1,2})",
+  j: "(\\d{1,2})",
   l: "", // locale-dependent, setup on runtime
-  m: "(\\d\\d|\\d)",
-  n: "(\\d\\d|\\d)",
-  s: "(\\d\\d|\\d)",
-  u: "(.+)",
-  w: "(\\d\\d|\\d)",
+  m: "(\\d{1,2})",
+  n: "(\\d{1,2})",
+  s: "(\\d{1,2})",
+  u: "(\\d+(?:\\.\\d+)?)",
+  w: "(\\d{1,2})",
   y: "(\\d{2})",
 };
 
@@ -193,7 +193,7 @@ export const formats: Formats = {
     return monthToStr(date.getMonth(), true, locale);
   },
 
-  // seconds 00-59
+  // seconds (00-59)
   S: (date: Date) => pad(date.getSeconds()),
 
   // unix timestamp
@@ -229,7 +229,7 @@ export const formats: Formats = {
   // the month number (1-12)
   n: (date: Date) => date.getMonth() + 1,
 
-  // seconds 0-59
+  // seconds (0-59)
   s: (date: Date) => date.getSeconds(),
 
   // Unix Milliseconds

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,10 @@
-export const pad = (number: string | number, length = 2) =>
-  `000${number}`.slice(length * -1);
+export const pad = (number: string | number, length = 2) => {
+  let res = "" + number;
+  while (res.length < length) {
+    res = "0" + res;
+  }
+  return res;
+};
 export const int = (bool: boolean) => (bool === true ? 1 : 0);
 
 /* istanbul ignore next */


### PR DESCRIPTION
This PR adds fractional seconds support for direct input with nanosecond resolution.

The implementation is inspired by #2870 but:
- resolution is not limited to milliseconds
- fractional seconds has no extra formatting token
- format resolution is controlled by `formatSecondsPrecision` option, any fixed digits are supported, -1 can be used for dynamic length
- provides well tested implementation

`allowInput` (direct input modification) support is well implemented and tested for typical usecases. This PR does not aim to provide UI for setting fractional seconds via flatpickr popup in order to focus on the flatpickr internal implementation. Once this PR is merged, the UI can be easily added.

Related with:
- #1361
- #2520#issuecomment-912684318
- https://github.com/phpmyadmin/phpmyadmin/issues/17604
- https://github.com/atk4/ui/pull/2067

/cc @Aditya-ds-1806  @williamdes @chmln

Sponsored by my own company.