### PR TITLE
Add step increment option for seconds

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1241,8 +1241,8 @@ describe("flatpickr", () => {
     it("time input and increments", () => {
       createInstance({
         enableTime: true,
+        minuteIncrement: 10,
         defaultDate: "2017-1-1 10:00",
-        //minDate: "2017-1-01 3:35",
       });
 
       expect(fp.hourElement).toBeDefined();
@@ -1259,7 +1259,7 @@ describe("flatpickr", () => {
       expect(fp.hourElement.value).toEqual("11");
 
       incrementTime("minuteElement", 1);
-      expect(fp.minuteElement.value).toEqual("05");
+      expect(fp.minuteElement.value).toEqual("10");
 
       simulate("click", fp.amPM, { which: 1 }, MouseEvent);
       expect(fp.amPM.textContent).toEqual("PM");
@@ -1276,9 +1276,39 @@ describe("flatpickr", () => {
       expect(fp.hourElement.value).toEqual("09");
     });
 
+    it("time input and seconds increment", () => {
+      createInstance({
+        enableTime: true,
+        enableSeconds: true,
+        secondIncrement: 15,
+        defaultDate: "2017-1-1 10:00:30",
+      });
+
+      expect(fp.minuteElement).toBeDefined();
+      expect(fp.secondElement).toBeDefined();
+
+      if (!fp.minuteElement || !fp.secondElement) return;
+
+      expect(fp.minuteElement.value).toEqual("00");
+      expect(fp.secondElement.value).toEqual("30");
+
+      incrementTime("minuteElement", 1);
+      expect(fp.minuteElement.value).toEqual("01");
+      expect(fp.secondElement.value).toEqual("30");
+
+      incrementTime("secondElement", 1);
+      expect(fp.minuteElement.value).toEqual("01");
+      expect(fp.secondElement.value).toEqual("45");
+
+      incrementTime("minuteElement", 1);
+      expect(fp.minuteElement.value).toEqual("02");
+      expect(fp.secondElement.value).toEqual("45");
+    });
+
     it("time input respects minDate", () => {
       createInstance({
         enableTime: true,
+        minuteIncrement: 5,
         dateFormat: "Y-m-d H:i",
         defaultDate: "2017-1-1 4:00",
         minDate: "2017-1-01 3:35",
@@ -1319,6 +1349,7 @@ describe("flatpickr", () => {
     it("time input respects maxDate", () => {
       createInstance({
         enableTime: true,
+        minuteIncrement: 5,
         defaultDate: "2017-1-1 3:00",
         maxDate: "2017-1-01 3:35",
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1207,7 +1207,7 @@ function FlatpickrInstance(
 
       self.secondElement.setAttribute(
         "step",
-        self.minuteElement.getAttribute("step") as string
+        self.config.secondIncrement.toString()
       );
       self.secondElement.setAttribute("min", "0");
       self.secondElement.setAttribute("max", "59");

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -248,6 +248,9 @@ Use it along with "enableTime" to create a time picker. */
   /* HTML for the left arrow icon, used to switch months. */
   prevArrow: string;
 
+  /* Adjusts the step for the second input (incl. scrolling) */
+  secondIncrement: number;
+
   /* Whether to display the current month name in shorthand mode, e.g. "Sep" instead "September" */
   shorthandCurrentMonth: boolean;
 
@@ -332,6 +335,7 @@ export interface ParsedOptions {
   position: BaseOptions["position"];
   positionElement?: HTMLElement;
   prevArrow: string;
+  secondIncrement: number;
   shorthandCurrentMonth: boolean;
   showMonths: number;
   static: boolean;
@@ -414,6 +418,7 @@ export const defaults: ParsedOptions = {
   positionElement: undefined,
   prevArrow:
     "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M5.207 8.471l7.146 7.147-0.707 0.707-7.853-7.854 7.854-7.853 0.707 0.707-7.147 7.146z' /></svg>",
+  secondIncrement: 1,
   shorthandCurrentMonth: false,
   showMonths: 1,
   static: false,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -164,8 +164,7 @@ By default, Flatpickr utilizes native datetime widgets unless certain options (e
   /* The minimum time that a user can start picking from (inclusive). */
   minTime: DateOption;
 
-  /* Adjusts the step for the minute input (incl. scrolling)
-  Defaults to 5 */
+  /* Adjusts the step for the minute input (incl. scrolling) */
   minuteIncrement: number;
 
   /* Date selection mode, defaults to "single" */
@@ -391,7 +390,7 @@ export const defaults: ParsedOptions = {
   ignoredFocusElements: [],
   inline: false,
   locale: "default",
-  minuteIncrement: 5,
+  minuteIncrement: 1,
   mode: "single",
   monthSelectorType: "dropdown",
   nextArrow:


### PR DESCRIPTION
This PR adds a separate step increment ooption for seconds. Previous the step increment for seconds was the same as for minutes.

Separate option is consistent as hours has separate config as well.

Also make the step increment default to 1 as non-1 step behaves quite unexpected - the number after one step increment is not ceiled, so for ex. minute set to 3 with one increment increments the value to 8 instead of 5 I would expect.