### PR TITLE
Fix flatpickr close after non-calendar blur with direct input

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1895,29 +1895,65 @@ describe("flatpickr", () => {
   });
 
   describe("events + hooks", () => {
-    describe("onOpen", () => {
-      it("should fire only once", () => {
-        let timesFired = 0;
+    it("onOpen/onClose should fire only once", () => {
+      let openTimesFired = 0;
+      let closeTimesFired = 0;
 
-        const fp = createInstance({
-          onOpen: () => timesFired++,
-        });
-
-        fp.open();
-        expect(timesFired).toEqual(1);
+      const fp = createInstance({
+        onOpen: () => openTimesFired++,
+        onClose: () => closeTimesFired++,
       });
+
+      expect(fp.isOpen).toBe(false);
+      expect(openTimesFired).toEqual(0);
+      expect(closeTimesFired).toEqual(0);
+
+      fp.open();
+      expect(fp.isOpen).toBe(true);
+      expect(openTimesFired).toEqual(1);
+      expect(closeTimesFired).toEqual(0);
+
+      fp.close();
+      expect(fp.isOpen).toBe(false);
+      expect(openTimesFired).toEqual(1);
+      expect(closeTimesFired).toEqual(1);
     });
-    describe("onBlur", () => {
-      it("doesn't misfire", () => {
-        let timesFired = 0;
-        const fp = createInstance({
-          allowInput: true,
-          onChange: () => timesFired++,
-        });
-        fp._input.focus();
-        simulate("blur", fp._input);
-        expect(timesFired).toEqual(0);
+
+    it("onOpen/onClose should fire only once with allowInput and focus/blur", async () => {
+      let openTimesFired = 0;
+      let closeTimesFired = 0;
+
+      const fp = createInstance({
+        allowInput: true,
+        onOpen: () => openTimesFired++,
+        onClose: () => closeTimesFired++,
       });
+
+      expect(fp.isOpen).toBe(false);
+      expect(openTimesFired).toEqual(0);
+      expect(closeTimesFired).toEqual(0);
+
+      fp.input.focus();
+      expect(fp.isOpen).toBe(true);
+      expect(openTimesFired).toEqual(1);
+      expect(closeTimesFired).toEqual(0);
+
+      fp.input.blur();
+      jest.runAllTimers();
+      expect(fp.isOpen).toBe(false);
+      expect(openTimesFired).toEqual(1);
+      expect(closeTimesFired).toEqual(1);
+    });
+
+    it("onBlur doesn't misfire", () => {
+      let timesFired = 0;
+      const fp = createInstance({
+        allowInput: true,
+        onChange: () => timesFired++,
+      });
+      fp._input.focus();
+      simulate("blur", fp._input);
+      expect(timesFired).toEqual(0);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1448,7 +1448,7 @@ function FlatpickrInstance(
     });
   }
 
-  function isCalendarElem(elem: HTMLElement) {
+  function isCalendarElem(elem: Element) {
     return self.calendarContainer.contains(elem);
   }
 
@@ -1637,6 +1637,21 @@ function FlatpickrInstance(
           : self.config.dateFormat
       );
     }
+
+    setTimeout(function () {
+      // timeout is needed for document.activeElement to be the element after blur
+      if (self.isOpen) {
+        const activeElement = getClosestActiveElement();
+        if (
+          activeElement &&
+          activeElement !== self.input &&
+          activeElement !== self.altInput &&
+          !isCalendarElem(activeElement)
+        ) {
+          documentClick({ target: null } as MouseEvent);
+        }
+      }
+    }, 0);
   }
 
   function onKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
When `allowInput` is enabled, blur event must close the flatpickr calendar when the newly focused element is outside the flatpick calendar.

This can happen at least when `fp.input.blur()` is called from user code or implied by default browser escape key handler.