### PR TITLE
avoid update values when there is nothing to update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2834,6 +2834,9 @@ function FlatpickrInstance(
    * Updates the values of inputs associated with the calendar
    */
   function updateValue(triggerChange = true) {
+    if (self.selectedDates.length === 0) {
+        return;
+    }
     if (self.mobileInput !== undefined && self.mobileFormatStr) {
       self.mobileInput.value =
         self.latestSelectedDateObj !== undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -2834,14 +2834,15 @@ function FlatpickrInstance(
    * Updates the values of inputs associated with the calendar
    */
   function updateValue(triggerChange = true) {
-    if (self.selectedDates.length === 0) {
-        return;
-    }
     if (self.mobileInput !== undefined && self.mobileFormatStr) {
       self.mobileInput.value =
         self.latestSelectedDateObj !== undefined
           ? self.formatDate(self.latestSelectedDateObj, self.mobileFormatStr)
           : "";
+    }
+
+    if (self.selectedDates.length === 0) {
+        return;
     }
 
     self.input.value = getDateStr(self.config.dateFormat);


### PR DESCRIPTION
also avoids update races, for my use in particularly fixes a wasm value update conflict.
besides the efficiency improvement, this might resolve interoperability with conflicting updates.

non breaking change