### PR TITLE
Update id.ts

### DIFF
--- a/src/l10n/id.ts
+++ b/src/l10n/id.ts
@@ -52,7 +52,7 @@ export const Indonesian: CustomLocale = {
     return "";
   },
   time_24hr: true,
-  rangeSeparator: " - ",
+  rangeSeparator: " sampai ",
 };
 
 fp.l10ns.id = Indonesian;


### PR DESCRIPTION
Changed separator text for Indonesian dateRange from "-" to "sampai". "Sampai" is ID translation of "until", and we rarely use the dash symbol to connect between two different full-date (d-m-Y).

Should not produces any significant bugs as this is purely a cosmetic change. Although, according to ID spelling/grammar guidebook, an EM dash — is used to connect between two adjacent numbers. Users might have to style their own instance depending on the output they have.

ref: https://eyd.netlify.app/penggunaan-tanda-baca/tanda-pisah