### PR TITLE
Add few more dynamic config support for non-native date picker

### DIFF
--- a/src/style/flatpickr.styl
+++ b/src/style/flatpickr.styl
@@ -182,7 +182,7 @@
     cursor pointer
     position absolute
     top 0
-    height $monthNavHeight
+    height ($monthNavHeight - 20px)
     padding 10px
     z-index 3
     color $monthForeground


### PR DESCRIPTION
**Overview:**
This pull request introduces dynamic configuration options for enhancing the Flatpickr library's non-native date picker. It empowers users to customize their date picker experience with greater flexibility.

**Features Added:**
Added dynamic config support for below properties:

`monthSelectorType`: Allows users to define the month selector type for better navigation.
`allowInput`: Enables/disables the manual input of dates.
`enableTime`, `time_24hr`, `enableSeconds`: Allows time-related configurations for precision.
`weekNumbers`: Adds support for displaying week numbers in the date picker.

**Implementation Details:**
The implementation involved extending the configuration options within the Flatpickr library, enabling the specified properties to accept dynamic changes based on user preferences.

**Note:**
_Dynamic configuration currently doesn't support the native date time picker._

**Benefits:**
These dynamic configurations empower users to tailor their date picker according to their specific needs, enhancing usability and flexibility in diverse applications.

**Request for Feedback:**
Feedback from the maintainers and community contributors is welcomed for further refinement and improvement.

Thank you for considering this enhancement!