### PR TITLE
Allows to select ranges including disabled days

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2319,6 +2319,7 @@ function FlatpickrInstance(
   function selectDate(e: MouseEvent | KeyboardEvent) {
     e.preventDefault();
     e.stopPropagation();
+    onMouseOver(getEventTarget(e) as DayElement);;
 
     const isSelectable = (day: Element) =>
       day.classList &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -2319,7 +2319,7 @@ function FlatpickrInstance(
   function selectDate(e: MouseEvent | KeyboardEvent) {
     e.preventDefault();
     e.stopPropagation();
-    onMouseOver(getEventTarget(e) as DayElement);;
+    onMouseOver(getEventTarget(e) as DayElement);
 
     const isSelectable = (day: Element) =>
       day.classList &&


### PR DESCRIPTION
Tis PR is for fixing an issue on selected dates related to selection with disable dates interval on a range datepicker. This issue is caused when the selectedDate() method is triggered and in some use cases, the flatpickr classes isn't added to datepicker:
![image](https://github.com/flatpickr/flatpickr/assets/25321845/b856cefa-3be4-4d4e-abc1-af191f91b0a1)

This issue only occurs on **phone devices**.

### What was done
- Add a method call, onMouseOver(), into selectedDate() methiod to set / update the datepicker class and add the validation for a selection date
![image](https://github.com/flatpickr/flatpickr/assets/25321845/35551eef-30c2-4df0-87a7-a05ff3ec0b35)
