### PR TITLE
fix: remove clear after one selected date

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1498,13 +1498,6 @@ function FlatpickrInstance(
         }
 
         self.close();
-
-        if (
-          self.config &&
-          self.config.mode === "range" &&
-          self.selectedDates.length === 1
-        )
-          self.clear(false);
       }
     }
   }


### PR DESCRIPTION
Hy,

I want to apologize for my english, I'm a fresh student in computer science.

I have a website where i want to select only the begin date of a range. But when it happens, flatpickr clear the range. I thing it's not at flatpickr to force the clear, but  at the user to decide this in the onValueUpdate event or in the onClose event.

Also, a lot a famous Website allow to select only the begin date of a range, like airplane companies or booking websites.

 