### PR TITLE
fix: do not statically cache today's date

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2562,7 +2562,9 @@ function FlatpickrInstance(
 
   function setupDates() {
     self.selectedDates = [];
-    self.now = self.parseDate(self.config.now) || new Date();
+    self.now =
+      (self.config.now ? self.parseDate(self.config.now) : undefined) ||
+      new Date();
 
     // Workaround IE11 setting placeholder as the input's value
     const preloadedDate =

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -315,7 +315,7 @@ export interface ParsedOptions {
   monthSelectorType: string;
   nextArrow: string;
   noCalendar: boolean;
-  now: Date;
+  now?: Date;
   onChange: Hook[];
   onClose: Hook[];
   onDayCreate: Hook[];
@@ -397,7 +397,6 @@ export const defaults: ParsedOptions = {
   nextArrow:
     "<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 17 17'><g></g><path d='M13.207 8.472l-7.854 7.854-0.707-0.707 7.146-7.146-7.146-7.148 0.707-0.707 7.854 7.854z' /></svg>",
   noCalendar: false,
-  now: new Date(),
   onChange: [],
   onClose: [],
   onDayCreate: [],


### PR DESCRIPTION
Hey there, first of all thanks for developing and maintaining this library, it proved itself very useful!

I stumbled over the following issue a few days ago: Whenever a user kept my app open over multiple days, flatpickr's value for today is outdated. This affected all flatpickrs instances, even newly created ones.

Turns out that `self.now` of a flatpickr instance is initialized with the value stored in `self.options.now`. This value is statically initialized and won't be updated as long as the modules stay in memory. I guess that my issue is related to https://github.com/flatpickr/flatpickr/issues/1633, but redrawing does not help in this case.

I am not sure about the reasons behind caching `options.now` and propose to remove it altogether. What do you think?

Thanks a lot for looking into my PR,
remolueoend