### PR TITLE
fix: access stylesheet causing security error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2276,9 +2276,8 @@ function FlatpickrInstance(
     let editableSheet = null;
     for (let i = 0; i < document.styleSheets.length; i++) {
       const sheet = document.styleSheets[i] as CSSStyleSheet;
-      if (!sheet.cssRules) continue;
       try {
-        sheet.cssRules;
+        if (!sheet.cssRules) continue;
       } catch (err) {
         continue;
       }


### PR DESCRIPTION
Original fix: https://github.com/flatpickr/flatpickr/pull/1988

Accessing `if (!sheet.cssRules) continue;` break it again
https://github.com/flatpickr/flatpickr/commit/32085ed0167421de7a7493848ec149b550856467