### PR TITLE
Fix month select issue when Enter key is pressed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -366,6 +366,11 @@ function FlatpickrInstance(
    */
   function onYearInput(event: KeyboardEvent & IncrementEvent) {
     const eventTarget = getEventTarget(event) as HTMLInputElement;
+
+    if(eventTarget !== self.yearElements[0]) {
+      return;
+    }
+
     const year = parseInt(eventTarget.value) + (event.delta || 0);
 
     if (
@@ -2331,10 +2336,13 @@ function FlatpickrInstance(
     if (t === undefined) return;
 
     const target = t as DayElement;
+    const newDate = target ? new Date(target.dateObj.getTime()) : self.latestSelectedDateObj as Date;
 
-    const selectedDate = (self.latestSelectedDateObj = new Date(
-      target.dateObj.getTime()
-    ));
+    if(self.latestSelectedDateObj !== newDate) {
+      self.latestSelectedDateObj = newDate;
+    }
+
+    const selectedDate = newDate;
 
     const shouldChangeMonth =
       (selectedDate.getMonth() < self.currentMonth ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -1736,6 +1736,9 @@ function FlatpickrInstance(
 
         case 38:
         case 40:
+          if ((eventTarget as HTMLElement).tagName === "SELECT") {
+            break;
+          }
           e.preventDefault();
           const delta = e.keyCode === 40 ? 1 : -1;
           if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1693,7 +1693,11 @@ function FlatpickrInstance(
             e.preventDefault();
             updateTime();
             focusAndClose();
-          } else selectDate(e);
+          } else if ((eventTarget as HTMLElement).tagName === "SELECT") {
+            break;
+          } else {
+            selectDate(e)
+          };
 
           break;
 


### PR DESCRIPTION
This PR will fix the following issues:
- Fixed the issue that was causing year to be update when Enter key was pressed at the month select only if month didn't change;
- Improve the month selector in order to give the ability to open it also by using arrows up and down keys;

> **Preview:**
>> **With Issue**:
>>![dp-issue](https://github.com/user-attachments/assets/b1ff6631-50e9-435a-9c98-68979929795c)
>
>> **Fixed**:
>> ![dp-fixed](https://github.com/user-attachments/assets/61b6a556-a6a6-4512-8393-458881a86d32)
