### PR TITLE
Added rangeConjunction

### DIFF
--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1705,7 +1705,7 @@ describe("flatpickr", () => {
     it("can set range conjunction", () => {
       createInstance({
         mode: "range",
-        rangeConjunction: ', '
+        rangeConjunction: ", ",
       });
 
       fp.setDate("2016-1-17");

--- a/__tests__/src/index.spec.ts
+++ b/__tests__/src/index.spec.ts
@@ -1702,6 +1702,19 @@ describe("flatpickr", () => {
       expect(fp.input.value).toEqual("2016-01-13 to 2016-01-17");
     });
 
+    it("can set range conjunction", () => {
+      createInstance({
+        mode: "range",
+        rangeConjunction: ', '
+      });
+
+      fp.setDate("2016-1-17");
+
+      simulate("click", fp.days.childNodes[17], { which: 1 }, MouseEvent);
+      expect(fp.selectedDates.length).toEqual(2);
+      expect(fp.input.value).toEqual("2016-01-13, 2016-01-17");
+    });
+
     it("adds disabled class to disabled prev/next month arrows", () => {
       const isArrowDisabled = (which: "prevMonthNav" | "nextMonthNav") =>
         fp[which].classList.contains("flatpickr-disabled");

--- a/src/index.ts
+++ b/src/index.ts
@@ -2830,9 +2830,10 @@ function FlatpickrInstance(
       );
   }
 
-  function getDateRangeSeparator()
-  {
-    return typeof self.config.rangeConjunction === 'string' ? self.config.rangeConjunction : self.l10n.rangeSeparator;
+  function getDateRangeSeparator() {
+    return typeof self.config.rangeConjunction === "string"
+      ? self.config.rangeConjunction
+      : self.l10n.rangeSeparator;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2826,8 +2826,13 @@ function FlatpickrInstance(
       .join(
         self.config.mode !== "range"
           ? self.config.conjunction
-          : self.l10n.rangeSeparator
+          : getDateRangeSeparator()
       );
+  }
+
+  function getDateRangeSeparator()
+  {
+    return typeof self.config.rangeConjunction === 'string' ? self.config.rangeConjunction : self.l10n.rangeSeparator;
   }
 
   /**

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -92,6 +92,12 @@ export interface BaseOptions {
     selected dates together for the date input value.
   */
   conjunction: string;
+  
+  /*
+    If "mode" is "range" and rangeConjunction is set, this string will be used to join
+    selected dates together for the date input value.
+  */
+  rangeConjunction: null | string;
 
   /*
     A string of characters which are used to define how the date will be displayed in the input box.
@@ -289,6 +295,7 @@ export interface ParsedOptions {
   clickOpens: boolean;
   closeOnSelect: boolean;
   conjunction: string;
+  rangeConjunction: null | string;
   dateFormat: string;
   defaultDate?: Date | Date[];
   defaultHour: number;
@@ -356,6 +363,7 @@ export const defaults: ParsedOptions = {
   clickOpens: true,
   closeOnSelect: true,
   conjunction: ", ",
+  rangeConjunction: null,
   dateFormat: "Y-m-d",
   defaultHour: 12,
   defaultMinute: 0,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -92,7 +92,7 @@ export interface BaseOptions {
     selected dates together for the date input value.
   */
   conjunction: string;
-  
+
   /*
     If "mode" is "range" and rangeConjunction is set, this string will be used to join
     selected dates together for the date input value.


### PR DESCRIPTION
I would like to retrieve the start and end dates as an array within my system. Currently, the start and end dates are merged into a single string using a localized separator. However, in a multilingual system, splitting this string becomes challenging due to the varying separators used across languages.

To address this, my proposal is to introduce a new property: rangeConjunction. This would allow us to specify a consistent separator, such as a comma or dash, making it easier to convert the string back into an array with distinct start and end dates. When the rangeConjunction is not set, it will fall back to the localized separator. 

Let me know if this works or if you’d like any further adjustments!