### PR TITLE
Move DEBOUNCED_CHANGE_MS to configs to allow custom debouncing value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,6 @@ import { tokenRegex, monthToStr } from "./utils/formatting";
 
 import "./utils/polyfills";
 
-const DEBOUNCED_CHANGE_MS = 300;
-
 function FlatpickrInstance(
   element: HTMLElement,
   instanceConfig?: Options
@@ -428,7 +426,10 @@ function FlatpickrInstance(
     }
 
     const debouncedResize = debounce(onResize, 50);
-    self._debouncedChange = debounce(triggerChange, DEBOUNCED_CHANGE_MS);
+    self._debouncedChange = debounce(
+      triggerChange,
+      self.config.debouncedChangeMs
+    );
 
     if (self.daysContainer && !/iPhone|iPad|iPod/i.test(navigator.userAgent))
       bind(self.daysContainer, "mouseover", (e: MouseEvent) => {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -290,6 +290,7 @@ export interface ParsedOptions {
   closeOnSelect: boolean;
   conjunction: string;
   dateFormat: string;
+  debouncedChangeMs: number;
   defaultDate?: Date | Date[];
   defaultHour: number;
   defaultMinute: number;
@@ -357,6 +358,7 @@ export const defaults: ParsedOptions = {
   closeOnSelect: true,
   conjunction: ", ",
   dateFormat: "Y-m-d",
+  debouncedChangeMs: 300,
   defaultHour: 12,
   defaultMinute: 0,
   defaultSeconds: 0,


### PR DESCRIPTION
Move the DEBOUNCED_CHANGE_MS const to default settings to allow users setting the debounce time before onChange is triggered.