### PR TITLE
Improve inserted dates not being case sensitive.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2159,8 +2159,8 @@ function FlatpickrInstance(
 
     tokenRegex.D = `(${self.l10n.weekdays.shorthand.join("|")})`;
     tokenRegex.l = `(${self.l10n.weekdays.longhand.join("|")})`;
-    tokenRegex.M = "(" + self.l10n.months.shorthand.join("|") + "|" + self.l10n.months.shorthand.join("|").toLowerCase() + ")";
-    tokenRegex.F = "(" + self.l10n.months.longhand.join("|") + "|" + self.l10n.months.longhand.join("|").toLowerCase() + ")";
+    tokenRegex.M = "(" + self.l10n.months.shorthand.join("|") + ")";
+    tokenRegex.F = "(" + self.l10n.months.longhand.join("|") + ")";
     tokenRegex.K = `(${self.l10n.amPM[0]}|${
       self.l10n.amPM[1]
     }|${self.l10n.amPM[0].toLowerCase()}|${self.l10n.amPM[1].toLowerCase()})`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2159,8 +2159,8 @@ function FlatpickrInstance(
 
     tokenRegex.D = `(${self.l10n.weekdays.shorthand.join("|")})`;
     tokenRegex.l = `(${self.l10n.weekdays.longhand.join("|")})`;
-    tokenRegex.M = `(${self.l10n.months.shorthand.join("|")})`;
-    tokenRegex.F = `(${self.l10n.months.longhand.join("|")})`;
+    tokenRegex.M = "(" + self.l10n.months.shorthand.join("|") + "|" + self.l10n.months.shorthand.join("|").toLowerCase() + ")";
+    tokenRegex.F = "(" + self.l10n.months.longhand.join("|") + "|" + self.l10n.months.longhand.join("|").toLowerCase() + ")";
     tokenRegex.K = `(${self.l10n.amPM[0]}|${
       self.l10n.amPM[1]
     }|${self.l10n.amPM[0].toLowerCase()}|${self.l10n.amPM[1].toLowerCase()})`;

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -88,8 +88,8 @@ export const createDateParser = ({ config = defaults, l10n = english }) => (
         const escaped = format[i - 1] === "\\" || isBackSlash;
 
         if (tokenRegex[token] && !escaped) {
-          regexStr += tokenRegex[token];
-          const match = new RegExp(regexStr).exec(date);
+          regexStr += tokenRegex[token].toLowerCase();
+          const match = new RegExp(regexStr).exec(date.toLowerCase());
           if (match && (matched = true)) {
             ops[token !== "Y" ? "push" : "unshift"]({
               fn: revFormat[token],

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -44,7 +44,7 @@ export type RevFormat = Record<string, RevFormatFn>;
 export const revFormat: RevFormat = {
   D: doNothing,
   F: function (dateObj: Date, monthName: string, locale: Locale) {
-    dateObj.setMonth(locale.months.longhand.indexOf(monthName));
+    dateObj.setMonth(locale.months.longhand.join(",").toLowerCase().split(",").indexOf(monthName.toLowerCase()));
   },
   G: (dateObj: Date, hour: string) => {
     dateObj.setHours((dateObj.getHours() >= 12 ? 12 : 0) + parseFloat(hour));
@@ -62,7 +62,7 @@ export const revFormat: RevFormat = {
     );
   },
   M: function (dateObj: Date, shortMonth: string, locale: Locale) {
-    dateObj.setMonth(locale.months.shorthand.indexOf(shortMonth));
+    dateObj.setMonth(locale.months.shorthand.join(",").toLowerCase().split(",").indexOf(shortMonth.toLowerCase()));
   },
   S: (dateObj: Date, seconds: string) => {
     dateObj.setSeconds(parseFloat(seconds));


### PR DESCRIPTION
This PR will fix an issue that was caused when:

- allowInput = true;

If user insert day/month names in lowercase selectDate method was not being able to properly set the date once those values was not being found at locale list of available options.