### PR TITLE
Add support for composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "flatpickr/flatpickr",
+    "type": "library",
+    "description": "Lightweight, powerful javascript datetimepicker with no dependencies .",
+    "keywords": [
+        "datepicker",
+        "js"
+    ],
+    "homepage": "https://github.com/flatpickr/flatpickr",
+    "license": "MIT"
+}


### PR DESCRIPTION
This would make flow.js easy available for projects that not use package managers like npm.

With that file in place and published at packagist.org it takes a few lines in a composer-plugin to use the files from dist. E.g. https://github.com/OpenMage/composer-plugin