### PR TITLE
fix: month select plugin out of sync when setDate() is used to set selected date

### DIFF
--- a/src/plugins/monthSelect/index.ts
+++ b/src/plugins/monthSelect/index.ts
@@ -337,6 +337,8 @@ function monthSelectPlugin(pluginConfig?: Partial<Config>): Plugin {
         bindEvents,
         setCurrentlySelected,
         () => {
+          fp.config.onOpen.push(buildMonths);
+          fp.config.onOpen.push(selectYear);
           fp.config.onClose.push(closeHook);
           fp.loadedPlugins.push("monthSelect");
         },


### PR DESCRIPTION
This fixes a bug in the month select plugin where it will not show the correct selected date when tp.setDate() is used to set a selected date as described in #3067 

The proposed solution in the PR is to call selectYear and buildMonths functions on the onOpen event so the DOM can be properly updated with the new date selected.