### PR TITLE
Add translation for aria-label year

### DIFF
--- a/src/l10n/da.ts
+++ b/src/l10n/da.ts
@@ -62,6 +62,7 @@ export const Danish: CustomLocale = {
   rangeSeparator: " til ",
   weekAbbreviation: "uge",
   time_24hr: true,
+  yearAriaLabel: "år",
 };
 
 fp.l10ns.da = Danish;

--- a/src/l10n/de.ts
+++ b/src/l10n/de.ts
@@ -60,6 +60,7 @@ export const German: CustomLocale = {
   scrollTitle: "Zum Ändern scrollen",
   toggleTitle: "Zum Umschalten klicken",
   time_24hr: true,
+  yearAriaLabel: "Jahr",
 };
 
 fp.l10ns.de = German;

--- a/src/l10n/es.ts
+++ b/src/l10n/es.ts
@@ -61,6 +61,7 @@ export const Spanish: CustomLocale = {
   firstDayOfWeek: 1,
   rangeSeparator: " a ",
   time_24hr: true,
+  yearAriaLabel: "año",
 };
 
 fp.l10ns.es = Spanish;

--- a/src/l10n/fi.ts
+++ b/src/l10n/fi.ts
@@ -60,6 +60,7 @@ export const Finnish: CustomLocale = {
     return ".";
   },
   time_24hr: true,
+  yearAriaLabel: "vuosi",
 };
 
 fp.l10ns.fi = Finnish;

--- a/src/l10n/fr.ts
+++ b/src/l10n/fr.ts
@@ -66,6 +66,7 @@ export const French: CustomLocale = {
   scrollTitle: "Défiler pour augmenter la valeur",
   toggleTitle: "Cliquer pour basculer",
   time_24hr: true,
+  yearAriaLabel: "année",
 };
 
 fp.l10ns.fr = French;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -60,6 +60,7 @@ export const Italian: CustomLocale = {
   scrollTitle: "Scrolla per aumentare",
   toggleTitle: "Clicca per cambiare",
   time_24hr: true,
+  yearAriaLabel: "anno", 
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -61,7 +61,6 @@ export const Italian: CustomLocale = {
   toggleTitle: "Clicca per cambiare",
   time_24hr: true,
   yearAriaLabel: "anno", 
-  
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -60,7 +60,6 @@ export const Italian: CustomLocale = {
   scrollTitle: "Scrolla per aumentare",
   toggleTitle: "Clicca per cambiare",
   time_24hr: true,
-  yearAriaLabel: "anno", 
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -58,9 +58,9 @@ export const Italian: CustomLocale = {
   rangeSeparator: " al ",
   weekAbbreviation: "Se",
   scrollTitle: "Scrolla per aumentare",
-  yearAriaLabel: "anno", 
   toggleTitle: "Clicca per cambiare",
-  time_24hr: true, 
+  time_24hr: true,
+  yearAriaLabel: "rok", 
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -58,8 +58,9 @@ export const Italian: CustomLocale = {
   rangeSeparator: " al ",
   weekAbbreviation: "Se",
   scrollTitle: "Scrolla per aumentare",
+  yearAriaLabel: "anno", 
   toggleTitle: "Clicca per cambiare",
-  time_24hr: true,
+  time_24hr: true, 
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -60,7 +60,6 @@ export const Italian: CustomLocale = {
   scrollTitle: "Scrolla per aumentare",
   toggleTitle: "Clicca per cambiare",
   time_24hr: true,
-  yearAriaLabel: "rok", 
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/it.ts
+++ b/src/l10n/it.ts
@@ -61,6 +61,7 @@ export const Italian: CustomLocale = {
   toggleTitle: "Clicca per cambiare",
   time_24hr: true,
   yearAriaLabel: "anno", 
+  
 };
 
 fp.l10ns.it = Italian;

--- a/src/l10n/ko.ts
+++ b/src/l10n/ko.ts
@@ -60,7 +60,7 @@ export const Korean: CustomLocale = {
 
   rangeSeparator: " ~ ",
   amPM: ["오전", "오후"],
-  yearAriaLabel:"년",
+  yearAriaLabel: "년",
 };
 
 fp.l10ns.ko = Korean;

--- a/src/l10n/ko.ts
+++ b/src/l10n/ko.ts
@@ -60,6 +60,7 @@ export const Korean: CustomLocale = {
 
   rangeSeparator: " ~ ",
   amPM: ["오전", "오후"],
+  yearAriaLabel:"년",
 };
 
 fp.l10ns.ko = Korean;

--- a/src/l10n/pl.ts
+++ b/src/l10n/pl.ts
@@ -59,6 +59,7 @@ export const Polish: CustomLocale = {
   toggleTitle: "Kliknij, aby przełączyć",
   firstDayOfWeek: 1,
   time_24hr: true,
+  yearAriaLabel: "rok",
 
   ordinal: () => {
     return ".";

--- a/src/l10n/pt.ts
+++ b/src/l10n/pt.ts
@@ -56,6 +56,7 @@ export const Portuguese: CustomLocale = {
 
   rangeSeparator: " até ",
   time_24hr: true,
+  yearAriaLabel: "ano",
 };
 
 fp.l10ns.pt = Portuguese;

--- a/src/l10n/sv.ts
+++ b/src/l10n/sv.ts
@@ -58,6 +58,7 @@ export const Swedish: CustomLocale = {
   },
   rangeSeparator: " till ",
   time_24hr: true,
+  yearAriaLabel: "år",
 
   ordinal: () => {
     return ".";

--- a/src/l10n/zh.ts
+++ b/src/l10n/zh.ts
@@ -58,6 +58,7 @@ export const Mandarin: CustomLocale = {
   weekAbbreviation: "周",
   scrollTitle: "滚动切换",
   toggleTitle: "点击切换 12/24 小时时制",
+  yearAriaLabel: "年",
 };
 
 fp.l10ns.zh = Mandarin;

--- a/src/l10n/zh_tw.ts
+++ b/src/l10n/zh_tw.ts
@@ -54,6 +54,7 @@ export const MandarinTraditional: CustomLocale = {
   weekAbbreviation: "週",
   scrollTitle: "滾動切換",
   toggleTitle: "點擊切換 12/24 小時時制",
+  yearAriaLabel: "年",
 };
 fp.l10ns.zh_tw = MandarinTraditional;
 export default fp.l10ns;


### PR DESCRIPTION
I am encountering an accessibility issue related to the aria-label attribute for the 'year' input in the Flatpickr component. Specifically, when I change the locale of my application (for instance, setting it to French, fr), I pass the appropriate locale to Flatpickr via its locale option. However, despite this, the aria-label for the 'year' field remains in English, not reflecting the selected locale. This indicates that the aria-label for the 'year' element is not being localized properly, even though other elements of the UI appear to be correctly translated.

I have confirmed that the locale is being correctly passed to the Flatpickr instance. The issue appears to be specifically with the localization of the aria-label attribute for the 'year' field, which is critical for screen reader accessibility.