### PR TITLE
Аdd Tajik (tj) locale support

### DIFF
--- a/src/l10n/index.ts
+++ b/src/l10n/index.ts
@@ -55,6 +55,7 @@ import { Slovenian as sl } from "./sl";
 import { Albanian as sq } from "./sq";
 import { Serbian as sr } from "./sr";
 import { Swedish as sv } from "./sv";
+import { Tajik as tj } from " ./tj";
 import { Thai as th } from "./th";
 import { Turkish as tr } from "./tr";
 import { Ukrainian as uk } from "./uk";
@@ -122,6 +123,7 @@ const l10n: Record<key, CustomLocale> = {
   sq,
   sr,
   sv,
+  tj,
   th,
   tr,
   uk,

--- a/src/l10n/tj.ts
+++ b/src/l10n/tj.ts
@@ -1,0 +1,70 @@
+/* Tajik locale for flatpickr */
+import { CustomLocale } from "../types/locale";
+import { FlatpickrFn } from "../types/instance";
+
+const fp =
+  typeof window !== "undefined" && window.flatpickr !== undefined
+    ? window.flatpickr
+    : ({
+        l10ns: {},
+      } as FlatpickrFn);
+
+export const Tajik: CustomLocale = {
+  weekdays: {
+    shorthand: ["Яш", "Дш", "Сш", "Чш", "Пш", "Ҷм", "Шн"],
+    longhand: [
+      "Якшанбе",
+      "Душанбе",
+      "Сешанбе",
+      "Чоршанбе",
+      "Панҷшанбе",
+      "Ҷумъа",
+      "Шанбе",
+    ],
+  },
+  months: {
+    shorthand: [
+      "Янв",
+      "Фев",
+      "Мар",
+      "Апр",
+      "Май",
+      "Июн",
+      "Июл",
+      "Авг",
+      "Сен",
+      "Окт",
+      "Ноя",
+      "Дек",
+    ],
+    longhand: [
+      "Январ",
+      "Феврал",
+      "Март",
+      "Апрел",
+      "Май",
+      "Июн",
+      "Июл",
+      "Август",
+      "Сентябр",
+      "Октябр",
+      "Ноябр",
+      "Декабр",
+    ],
+  },
+  firstDayOfWeek: 1,
+  ordinal: function () {
+    return ""; // Порядковые суффиксы в таджикском не используются в датах
+  },
+  rangeSeparator: " то ",
+  weekAbbreviation: "Ҳафта",
+  scrollTitle: "Барои зиёд кардан гардонед",
+  toggleTitle: "Барои интихоб кардан пахш кунед",
+  amPM: ["AM", "PM"],
+  yearAriaLabel: "Сол",
+  time_24hr: true,
+};
+
+fp.l10ns.tj = Tajik;
+
+export default fp.l10ns;

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -169,6 +169,7 @@ export type key =
   | "sq"
   | "sr"
   | "sv"
+  | "tj"
   | "th"
   | "tr"
   | "uk"


### PR DESCRIPTION
This PR adds Tajik language (locale `tj`) for Flatpickr datepicker. Fully localized weekdays, months, labels, and direction strings.