### PR TITLE
feat(l10n): add daysInMonth and aria labels to az locale

### DIFF
--- a/src/l10n/az.ts
+++ b/src/l10n/az.ts
@@ -1,4 +1,4 @@
-/* Azerbaijan locals for flatpickr */
+/* Azerbaijani locals for flatpickr */
 import { CustomLocale } from "../types/locale";
 import { FlatpickrFn } from "../types/instance";
 
@@ -53,6 +53,7 @@ export const Azerbaijan: CustomLocale = {
       "Dekabr",
     ],
   },
+  daysInMonth: [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
   firstDayOfWeek: 1,
   ordinal: () => {
     return ".";
@@ -62,6 +63,10 @@ export const Azerbaijan: CustomLocale = {
   scrollTitle: "Artırmaq üçün sürüşdürün",
   toggleTitle: "Aç / Bağla",
   amPM: ["GƏ", "GS"],
+  yearAriaLabel: "İl",
+  monthAriaLabel: "Ay",
+  hourAriaLabel: "Saat",
+  minuteAriaLabel: "Dəqiqə",
   time_24hr: true,
 };
 


### PR DESCRIPTION
The Azerbaijani locale (`src/l10n/az.ts`) was missing several optional fields that the `CustomLocale` schema in `src/types/locale.ts` declares and that many other locale files already provide.

### Changes

1. **`daysInMonth`** added. Mirrors the default locale's `[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]`, giving date validation the same data Gregorian-calendar locales rely on.

2. **`yearAriaLabel` / `monthAriaLabel` / `hourAriaLabel` / `minuteAriaLabel`** added — `"İl"`, `"Ay"`, `"Saat"`, `"Dəqiqə"`. Without these, screen readers in Azerbaijani UIs fall back to the English defaults in `default.ts` ("Year", "Month", "Hour", "Minute"), which is poor accessibility for Azerbaijani-speaking users.

3. **Header comment** corrected from `Azerbaijan locals` to `Azerbaijani locals`. The other locale files all use the language adjective in this slot (`German`, `French`, `Russian`, `Turkish`, etc.); "Azerbaijan" is the country name. (The plural `locals` typo is preserved to stay consistent with every other file in `src/l10n/`.)

No existing fields were touched, so nothing should change for current users of the `az` locale.
